### PR TITLE
Grant registry UI prototyping

### DIFF
--- a/app/.env.template
+++ b/app/.env.template
@@ -1,2 +1,2 @@
 VITE_BLOCKNATIVE_API_KEY=yourBlocknativeApiKey
-VITE_INFURA_API_KEY=yourInfuraApiKey
+VITE_INFURA_ID=yourInfuraApiKey

--- a/app/README.md
+++ b/app/README.md
@@ -39,6 +39,14 @@ yarn test:unit
 yarn test:e2e
 ```
 
+### Troubleshooting
+
+If you send a transaction in MetaMask against your local node, then restart your local node, your next transaction will use a nonce that is too large and your transaction will fail. To fix this, go to MetaMask Settings > Advanced > Reset Account. This will reset the MetaMask nonce counter so it matches what Hardhat is expecting.
+
+If you see `project ID does not have access to archive state` in the terminal, simply quit the process and re-run `yarn dev`. This happens because Infura only gives access to the last 128 blocks of data (~30 minutes), unless you pay for an archive node plan. If you leave your forked mainnet node running for longer than this, it tries to query for data older than 128 blocks and fails. Restarting your node re-forks from the latest mainnet block.
+
+If the app loads and the block number is zero after connecting your wallet, there's likely a `CALL_EXCEPTION` in the console. Simply refresh the page and this should be fixed.
+
 ## Notes / Customization
 
 Notes on customizing this app:

--- a/app/README.md
+++ b/app/README.md
@@ -16,13 +16,10 @@ Ethereum frontend app built with the following stack:
 # Install packages
 yarn install
 
-# Start local node and fill contract with dummy data (must be run before `yarn dev`)
+# Run in development mode (start local node and fills contract with dummy data)
 cd ../contracts
 yarn app:node
-yarn app:setup
 cd ../app
-
-# Run in development mode
 yarn dev
 
 # Compiles and minifies for production

--- a/app/README.md
+++ b/app/README.md
@@ -15,7 +15,7 @@ Ethereum frontend app built with the following stack:
 For local testing, add a network to MetaMask with the following information:
 
 - Name: Hardhat
-- New RPC URL: https://127.0.0.1:8545
+- New RPC URL: http://127.0.0.1:8545
 - Chain ID: 31337
 
 ```sh

--- a/app/README.md
+++ b/app/README.md
@@ -16,6 +16,12 @@ Ethereum frontend app built with the following stack:
 # Install packages
 yarn install
 
+# Start local node and fill contract with dummy data (must be run before `yarn dev`)
+cd ../contracts
+yarn app:node
+yarn app:setup
+cd ../app
+
 # Run in development mode
 yarn dev
 

--- a/app/README.md
+++ b/app/README.md
@@ -12,14 +12,17 @@ Ethereum frontend app built with the following stack:
 
 ## Setup
 
+For local testing, add a network to MetaMask with the following information:
+
+- Name: Hardhat
+- New RPC URL: https://127.0.0.1:8545
+- Chain ID: 31337
+
 ```sh
 # Install packages
 yarn install
 
-# Run in development mode (start local node and fills contract with dummy data)
-cd ../contracts
-yarn app:node
-cd ../app
+# Run in development mode (run this fom the repo root)
 yarn dev
 
 # Compiles and minifies for production

--- a/app/package.json
+++ b/app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "clean": "rimraf dist",
-    "dev": "cd ../contracts && yarn app:setup && cd ../app && vite",
+    "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",
     "serve": "vite preview",
     "test:unit": "vue-cli-service test:unit",

--- a/app/package.json
+++ b/app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "clean": "rimraf dist",
-    "dev": "vite",
+    "dev": "cd ../contracts && yarn app:setup && cd ../app && vite",
     "build": "vue-tsc --noEmit && vite build",
     "serve": "vite preview",
     "test:unit": "vue-cli-service test:unit",

--- a/app/package.json
+++ b/app/package.json
@@ -17,6 +17,7 @@
     "@dgrants/contracts": "^0.0.1",
     "@headlessui/vue": "^1.2.0",
     "@heroicons/vue": "^1.0.1",
+    "@tailwindcss/forms": "^0.3.3",
     "assert": "^2.0.0",
     "bnc-onboard": "^1.27.0",
     "crypto-browserify": "^3.12.0",

--- a/app/package.json
+++ b/app/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@dgrants/contracts": "^0.0.1",
+    "@dgrants/types": "^0.0.1",
     "@headlessui/vue": "^1.2.0",
     "@heroicons/vue": "^1.0.1",
     "@tailwindcss/forms": "^0.3.3",

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col min-h-screen">
     <layout-header id="header" />
-    <main id="app-main" class="flex-grow bg-white max-w-screen-lg mx-auto"><router-view /></main>
+    <main id="app-main" class="flex-grow justify-self-center bg-white"><router-view /></main>
     <layout-footer id="footer" />
   </div>
 </template>

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col min-h-screen">
     <layout-header id="header" />
-    <main id="app-main" class="flex-grow bg-white"><router-view /></main>
+    <main id="app-main" class="flex-grow bg-white max-w-screen-lg mx-auto"><router-view /></main>
     <layout-footer id="footer" />
   </div>
 </template>

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col min-h-screen">
     <layout-header id="header" />
-    <main id="app-main" class="flex-grow justify-self-center bg-white"><router-view /></main>
+    <main id="app-main" class="flex-grow bg-white"><router-view /></main>
     <layout-footer id="footer" />
   </div>
 </template>

--- a/app/src/components/BaseInput.vue
+++ b/app/src/components/BaseInput.vue
@@ -10,6 +10,7 @@
         class="
           hy
           appearance-none
+          bg-white
           block
           w-full
           px-3

--- a/app/src/components/BaseInput.vue
+++ b/app/src/components/BaseInput.vue
@@ -1,0 +1,70 @@
+<template>
+  <div>
+    <label :for="id" class="block text-sm font-medium text-gray-700"> {{ label }} </label>
+    <p :for="id" class="text-gray-500 text-sm">{{ description }}</p>
+    <div class="mt-1 relative">
+      <input
+        v-model="value"
+        @input="onInput"
+        :class="{ 'border-red-300 text-red-900 placeholder-red-300 focus:ring-red-500 focus:border-red-500': !isValid }"
+        class="
+          hy
+          appearance-none
+          block
+          w-full
+          px-3
+          py-2
+          border border-gray-300
+          rounded-md
+          shadow-sm
+          placeholder-gray-400
+          focus:outline-none focus:ring-primary-500 focus:border-primary-500
+          sm:text-sm
+        "
+        :id="id"
+        :name="id"
+        required
+        :type="type"
+      />
+      <div v-if="!isValid" class="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
+        <ExclamationCircleIcon class="h-5 w-5 text-red-500" aria-hidden="true" />
+      </div>
+    </div>
+    <p v-if="!isValid" class="mt-2 text-sm text-red-600" :id="`${id}-error`">{{ errorMsg }}</p>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue';
+import { ExclamationCircleIcon } from '@heroicons/vue/solid';
+
+export default defineComponent({
+  name: 'BaseInput',
+  components: { ExclamationCircleIcon },
+  props: {
+    // --- Required props ---
+    modelValue: { type: undefined, required: true, default: undefined }, // from v-model, don't pass this directly
+    // --- Optional props ---
+    label: { type: String, required: false, default: undefined }, // field label
+    description: { type: String, required: false, default: undefined }, // field description
+    errorMsg: { type: String, required: false, default: undefined }, // message to show on error
+    id: { type: String, required: false, default: undefined }, // id, for accessibility
+    placeholder: { type: String, required: false, default: undefined }, // input placeholder text
+    type: { type: String, required: false, default: 'text' }, // input type
+    rules: {
+      // Validation rules, as a function that returns a bool
+      type: Function,
+      required: false,
+      default: () => true,
+    },
+  },
+
+  setup(props, context) {
+    const isValid = ref(true);
+    function onInput() {
+      context.emit('update:modelValue', this.value);
+    }
+    return { onInput, isValid };
+  },
+});
+</script>

--- a/app/src/components/BaseInput.vue
+++ b/app/src/components/BaseInput.vue
@@ -4,7 +4,7 @@
     <p :for="id" class="text-gray-500 text-sm">{{ description }}</p>
     <div class="mt-1 relative">
       <input
-        v-model="value"
+        v-model="val"
         @input="onInput"
         :class="{ 'border-red-300 text-red-900 placeholder-red-300 focus:ring-red-500 focus:border-red-500': !isValid }"
         class="
@@ -27,7 +27,7 @@
         :type="type"
       />
       <div v-if="!isValid" class="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
-        <ExclamationCircleIcon class="h-5 w-5 text-red-500" aria-hidden="true" />
+        <ExclamationCircleIcon class="h-5 w-5 text-red-500" />
       </div>
     </div>
     <p v-if="!isValid" class="mt-2 text-sm text-red-600" :id="`${id}-error`">{{ errorMsg }}</p>
@@ -35,7 +35,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from 'vue';
+import { computed, defineComponent, ref } from 'vue';
 import { ExclamationCircleIcon } from '@heroicons/vue/solid';
 
 export default defineComponent({
@@ -52,7 +52,7 @@ export default defineComponent({
     placeholder: { type: String, required: false, default: undefined }, // input placeholder text
     type: { type: String, required: false, default: 'text' }, // input type
     rules: {
-      // Validation rules, as a function that returns a bool
+      // Validation rules, as a function that takes one input and returns a bool
       type: Function,
       required: false,
       default: () => true,
@@ -60,11 +60,12 @@ export default defineComponent({
   },
 
   setup(props, context) {
-    const isValid = ref(true);
+    const val = ref<any>(); // eslint-disable-line @typescript-eslint/no-explicit-any
+    const isValid = computed(() => (val.value ? props.rules(val.value) : true)); // assume valid if field is empty
     function onInput() {
-      context.emit('update:modelValue', this.value);
+      context.emit('update:modelValue', val.value);
     }
-    return { onInput, isValid };
+    return { onInput, isValid, val };
   },
 });
 </script>

--- a/app/src/components/BaseInput.vue
+++ b/app/src/components/BaseInput.vue
@@ -60,7 +60,7 @@ export default defineComponent({
   },
 
   setup(props, context) {
-    const val = ref<any>(); // eslint-disable-line @typescript-eslint/no-explicit-any
+    const val = ref<any>(props.modelValue); // eslint-disable-line @typescript-eslint/no-explicit-any
     const isValid = computed(() => (val.value ? props.rules(val.value) : true)); // assume valid if field is empty
     function onInput() {
       context.emit('update:modelValue', val.value);

--- a/app/src/components/LayoutHeader.vue
+++ b/app/src/components/LayoutHeader.vue
@@ -20,7 +20,7 @@
           </div>
         </div>
         <div class="ml-10 space-x-4">
-          <div v-if="userDisplayName">{{ userDisplayName }}</div>
+          <div v-if="userDisplayName" class="text-gray-700">{{ userDisplayName }}</div>
           <div v-else-if="!isSupportedNetwork" class="flex items-center">
             <ExclamationIcon class="h-5 w-5 text-yellow-500 mr-2" />
             <div class="text-gray-500">Unsupported network</div>

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -21,6 +21,9 @@
   .btn-primary {
     @apply font-medium text-white bg-primary-500 hover:bg-opacity-75 focus:outline-none;
   }
+  .btn-primary-disabled {
+    @apply bg-opacity-75 cursor-not-allowed;
+  }
   .btn-secondary {
     @apply font-medium text-primary-700 bg-primary-100 hover:bg-primary-200;
   }

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -30,6 +30,10 @@
   .btn-flat {
     @apply font-medium text-primary-600 hover:bg-primary-50;
   }
+
+  .link {
+    @apply text-primary-600 underline cursor-pointer;
+  }
 }
 
 /* Add styles to utilities */

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -30,13 +30,8 @@
   .btn-flat {
     @apply font-medium text-primary-600 hover:bg-primary-50;
   }
-
   .link {
     @apply text-primary-600 underline cursor-pointer;
-  }
-
-  .input {
-    @apply appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm;
   }
 }
 

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -34,6 +34,10 @@
   .link {
     @apply text-primary-600 underline cursor-pointer;
   }
+
+  .input {
+    @apply appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm;
+  }
 }
 
 /* Add styles to utilities */

--- a/app/src/router/index.ts
+++ b/app/src/router/index.ts
@@ -1,21 +1,20 @@
+/**
+ * @notice Router configuration
+ * @dev When the `component` property has an `import` statement, this gives route level code-splitting, which
+ * generates a separate chunk (e.g. `about.[hash].js`) for this route which is lazy-loaded when the route is visited
+ */
+
 import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router';
 import Home from '../views/Home.vue';
 
 // For info on using Vue Router with the Composition API, see https://next.router.vuejs.org/guide/advanced/composition-api.html
 
 const routes: Array<RouteRecordRaw> = [
-  {
-    path: '/',
-    name: 'Home',
-    component: Home,
-  },
-  {
-    path: '/about',
-    name: 'About',
-    // route level code-splitting
-    // this generates a separate chunk (about.[hash].js) for this route which is lazy-loaded when the route is visited.
-    component: () => import(/* webpackChunkName: "about" */ '../views/About.vue'),
-  },
+  { path: '/', name: 'Home', component: Home },
+  { path: '/about', name: 'About', component: () => import('../views/About.vue') },
+  { path: '/dgrants', name: 'dgrants', component: () => import('../views/GrantRegistryList.vue') },
+  { path: '/dgrants/new', name: 'dgrants-new', component: () => import('../views/GrantRegistryNewGrant.vue') },
+  { path: '/dgrants/:id', name: 'dgrants-id', component: () => import('../views/GrantRegistryGrantDetail.vue') },
   // Fallback route for handling 404s
   { path: '/:pathMatch(.*)*', name: '404', component: () => import('../views/Error404.vue') },
 ];

--- a/app/src/shims.d.ts
+++ b/app/src/shims.d.ts
@@ -1,9 +1,7 @@
 // Shim for Vue composition API
 declare module '*.vue' {
   import type { DefineComponent } from 'vue';
-  /* eslint-disable @typescript-eslint/no-explicit-any */
-  const component: DefineComponent<Record<string, unknown>, Record<string, unknown>, any>;
-  /* eslint-enable @typescript-eslint/no-explicit-any */
+  const component: DefineComponent<Record<string, unknown>, Record<string, unknown>, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
   export default component;
 }
 
@@ -16,6 +14,6 @@ declare module 'nightwind/helper';
 interface ImportMeta {
   env: {
     VITE_BLOCKNATIVE_API_KEY: string;
-    VITE_INFURA_API_KEY: string;
+    VITE_INFURA_ID: string;
   };
 }

--- a/app/src/store/data.ts
+++ b/app/src/store/data.ts
@@ -8,7 +8,20 @@ import { computed, ref } from 'vue';
 // --- Our imports ---
 import { BigNumber, Contract } from 'src/utils/ethers';
 import useWalletStore from 'src/store/wallet';
-import { MULTICALL_ADDRESS, MULTICALL_ABI } from 'src/utils/constants';
+import { GRANT_REGISTRY_ADDRESS, GRANT_REGISTRY_ABI, MULTICALL_ADDRESS, MULTICALL_ABI } from 'src/utils/constants';
+
+// --- Types ---
+// The output from ethers/typechain allows array or object access to grant data, so we must define types for
+// handling the Grant struct as done below
+type GrantObject = {
+  id: BigNumber;
+  owner: string;
+  payee: string;
+  metaPtr: string;
+};
+type GrantArray = [BigNumber, string, string, string];
+type GrantEthers = GrantArray & GrantObject;
+type Grant = GrantObject | GrantEthers;
 
 // --- Parameters required ---
 const { provider } = useWalletStore();
@@ -17,25 +30,29 @@ const { provider } = useWalletStore();
 // Most recent data read is saved as state
 const lastBlockNumber = ref<number>(0);
 const lastBlockTimestamp = ref<number>(0);
+const grants = ref<Grant[]>();
 
 // --- Store methods and exports ---
 export default function useDataStore() {
-  async function poll(multicall: Contract) {
+  async function poll(multicall: Contract, registry: Contract) {
     // Define calls to be read using multicall
     const calls = [
       { target: MULTICALL_ADDRESS, callData: multicall.interface.encodeFunctionData('getCurrentBlockTimestamp') },
+      { target: GRANT_REGISTRY_ADDRESS, callData: registry.interface.encodeFunctionData('getAllGrants') },
     ];
 
     // Execute calls
     const { blockNumber, returnData } = await multicall.tryBlockAndAggregate(false, calls);
 
     // Parse return data
-    const [timestampEncoded] = returnData;
+    const [timestampEncoded, grantsEncoded] = returnData;
     const { timestamp } = multicall.interface.decodeFunctionResult('getCurrentBlockTimestamp', timestampEncoded.returnData); // prettier-ignore
+    const grantsList = registry.interface.decodeFunctionResult('getAllGrants', grantsEncoded.returnData)[0]; // prettier-ignore
 
     // Save off data
     lastBlockNumber.value = (blockNumber as BigNumber).toNumber();
     lastBlockTimestamp.value = (timestamp as BigNumber).toNumber();
+    grants.value = grantsList as Grant[];
   }
 
   // Call this method to poll now, then poll on each new block
@@ -45,7 +62,8 @@ export default function useDataStore() {
 
     // Start polling with the user's provider if available, or fallback to our default provider
     const multicall = new Contract(MULTICALL_ADDRESS, MULTICALL_ABI, provider.value);
-    provider.value.on('block', (/* block: number */) => void poll(multicall));
+    const registry = new Contract(GRANT_REGISTRY_ADDRESS, GRANT_REGISTRY_ABI, provider.value);
+    provider.value.on('block', (/* block: number */) => void poll(multicall, registry));
   }
 
   return {
@@ -54,5 +72,6 @@ export default function useDataStore() {
     // Data
     lastBlockNumber: computed(() => lastBlockNumber.value || 0),
     lastBlockTimestamp: computed(() => lastBlockTimestamp.value || 0),
+    grants: computed(() => grants.value),
   };
 }

--- a/app/src/store/data.ts
+++ b/app/src/store/data.ts
@@ -2,45 +2,48 @@
  * @dev Poll on each block to read data
  */
 
-import { ref } from 'vue';
+// --- External imports ---
+import { computed, ref } from 'vue';
+
+// --- Our imports ---
 import { BigNumber, Contract } from 'src/utils/ethers';
 import useWalletStore from 'src/store/wallet';
 import { MULTICALL_ADDRESS, MULTICALL_ABI } from 'src/utils/constants';
 
-const { provider, userAddress } = useWalletStore();
+// --- Parameters required ---
+const { provider } = useWalletStore();
 
+// --- State ---
 // Most recent data read is saved as state
 const lastBlockNumber = ref<number>(0);
 const lastBlockTimestamp = ref<number>(0);
-const ethBalance = ref<bigint>();
 
+// --- Store methods and exports ---
 export default function useDataStore() {
   async function poll(multicall: Contract) {
-    // Don't poll if user has not connected wallet
-    if (!userAddress.value) return;
-
     // Define calls to be read using multicall
     const calls = [
       { target: MULTICALL_ADDRESS, callData: multicall.interface.encodeFunctionData('getCurrentBlockTimestamp') },
-      { target: MULTICALL_ADDRESS, callData: multicall.interface.encodeFunctionData('getEthBalance', [userAddress.value]) }, // prettier-ignore
     ];
 
     // Execute calls
     const { blockNumber, returnData } = await multicall.tryBlockAndAggregate(false, calls);
 
     // Parse return data
-    const [timestampEncoded, ethBalanceEncoded] = returnData;
+    const [timestampEncoded] = returnData;
     const { timestamp } = multicall.interface.decodeFunctionResult('getCurrentBlockTimestamp', timestampEncoded.returnData); // prettier-ignore
-    const { balance } = multicall.interface.decodeFunctionResult('getEthBalance', ethBalanceEncoded.returnData); // prettier-ignore
 
     // Save off data
     lastBlockNumber.value = (blockNumber as BigNumber).toNumber();
     lastBlockTimestamp.value = (timestamp as BigNumber).toNumber();
-    ethBalance.value = (balance as BigNumber).toBigInt();
   }
 
   // Call this method to poll now, then poll on each new block
   function startPolling() {
+    // Remove all existing listeners to avoid duplicate polling
+    provider.value.removeAllListeners();
+
+    // Start polling with the user's provider if available, or fallback to our default provider
     const multicall = new Contract(MULTICALL_ADDRESS, MULTICALL_ABI, provider.value);
     provider.value.on('block', (/* block: number */) => void poll(multicall));
   }
@@ -49,8 +52,7 @@ export default function useDataStore() {
     // Methods
     startPolling,
     // Data
-    lastBlockNumber,
-    lastBlockTimestamp,
-    ethBalance,
+    lastBlockNumber: computed(() => lastBlockNumber.value || 0),
+    lastBlockTimestamp: computed(() => lastBlockTimestamp.value || 0),
   };
 }

--- a/app/src/store/data.ts
+++ b/app/src/store/data.ts
@@ -48,7 +48,6 @@ export default function useDataStore() {
     lastBlockNumber.value = (blockNumber as BigNumber).toNumber();
     lastBlockTimestamp.value = (timestamp as BigNumber).toNumber();
     grants.value = grantsList as Grant[];
-    console.log('grants.value: ', grants.value);
   }
 
   /**

--- a/app/src/store/data.ts
+++ b/app/src/store/data.ts
@@ -9,19 +9,7 @@ import { computed, markRaw, ref } from 'vue';
 import { BigNumber, Contract } from 'src/utils/ethers';
 import useWalletStore from 'src/store/wallet';
 import { GRANT_REGISTRY_ADDRESS, GRANT_REGISTRY_ABI, MULTICALL_ADDRESS, MULTICALL_ABI } from 'src/utils/constants';
-
-// --- Types ---
-// The output from ethers/typechain allows array or object access to grant data, so we must define types for
-// handling the Grant struct as done below
-type GrantObject = {
-  id: BigNumber;
-  owner: string;
-  payee: string;
-  metaPtr: string;
-};
-type GrantArray = [BigNumber, string, string, string];
-type GrantEthers = GrantArray & GrantObject;
-type Grant = GrantObject | GrantEthers;
+import { Grant } from '@dgrants/types';
 
 // --- Parameters required ---
 const { provider } = useWalletStore();
@@ -60,6 +48,7 @@ export default function useDataStore() {
     lastBlockNumber.value = (blockNumber as BigNumber).toNumber();
     lastBlockTimestamp.value = (timestamp as BigNumber).toNumber();
     grants.value = grantsList as Grant[];
+    console.log('grants.value: ', grants.value);
   }
 
   /**

--- a/app/src/store/wallet.ts
+++ b/app/src/store/wallet.ts
@@ -31,7 +31,7 @@ import { getAddress } from 'src/utils/ethers';
 import { RPC_URL } from 'src/utils/constants';
 
 const { startPolling } = useDataStore();
-const { setLastWallet } = useSettingsStore();
+const { setLastWallet, isDark } = useSettingsStore();
 const defaultProvider = new JsonRpcProvider(RPC_URL);
 
 // State variables
@@ -71,7 +71,7 @@ export default function useWalletStore() {
   function initializeOnboard() {
     onboard = Onboard({
       dappId: import.meta.env.VITE_BLOCKNATIVE_API_KEY,
-      darkMode: false,
+      darkMode: isDark.value,
       networkId: 1,
       walletSelect: { wallets },
       walletCheck: walletChecks,

--- a/app/src/store/wallet.ts
+++ b/app/src/store/wallet.ts
@@ -53,7 +53,7 @@ function resetState() {
 }
 
 // Settings
-const infuraApiKey = import.meta.env.VITE_INFURA_API_KEY;
+const infuraApiKey = import.meta.env.VITE_INFURA_ID;
 const walletChecks = [{ checkName: 'connect' }];
 const wallets = [
   { walletName: 'metamask', preferred: true },

--- a/app/src/store/wallet.ts
+++ b/app/src/store/wallet.ts
@@ -24,7 +24,7 @@ import { computed, ref, markRaw } from 'vue';
 import useDataStore from 'src/store/data';
 import useSettingsStore from 'src/store/settings';
 import { JsonRpcProvider, JsonRpcSigner, Network, Web3Provider } from 'src/utils/ethers';
-import { formatAddress } from 'src/utils/formatters';
+import { formatAddress } from 'src/utils/utils';
 import Onboard from 'bnc-onboard';
 import { API as OnboardAPI } from 'bnc-onboard/dist/src/interfaces';
 import { getAddress } from 'src/utils/ethers';

--- a/app/src/store/wallet.ts
+++ b/app/src/store/wallet.ts
@@ -36,7 +36,7 @@ const defaultProvider = new JsonRpcProvider(RPC_URL);
 
 // State variables
 let onboard: OnboardAPI; // instance of Blocknative's onboard.js library
-const supportedChainIds = [1, 4]; // chain IDs supported by this app
+const supportedChainIds = [1, 4, 31337]; // chain IDs supported by this app
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const rawProvider = ref<any>(); // raw provider from the user's wallet, e.g. EIP-1193 provider
 /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/app/src/store/wallet.ts
+++ b/app/src/store/wallet.ts
@@ -43,7 +43,7 @@ const rawProvider = ref<any>(); // raw provider from the user's wallet, e.g. EIP
 const provider = ref<Web3Provider | JsonRpcProvider>(defaultProvider); // ethers provider
 const signer = ref<JsonRpcSigner>(); // ethers signer
 const userAddress = ref<string>(); // user's wallet address
-const userEns = ref<string>(); // user's ENS name
+const userEns = ref<string | null>(); // user's ENS name
 const network = ref<Network>(); // connected network, derived from provider
 
 // Reset state when, e.g.user switches wallets. Provider/signer are automatically updated by ethers so are not cleared
@@ -146,8 +146,8 @@ export default function useWalletStore() {
       return;
     }
 
-    // Get ENS name
-    const _userEns = await _provider.lookupAddress(_userAddress);
+    // Get ENS name if we're on mainnet
+    const _userEns = _network.chainId === 1 ? await _provider.lookupAddress(_userAddress) : null;
 
     // Now we save the user's info to the store. We don't do this earlier because the UI is reactive based on these
     // parameters, and we want to ensure this method completed successfully before updating the UI

--- a/app/src/utils/constants.ts
+++ b/app/src/utils/constants.ts
@@ -3,7 +3,6 @@ export const RPC_URL = `https://mainnet.infura.io/v3/${import.meta.env.VITE_INFU
 
 // Read data using Multicall2: https://github.com/makerdao/multicall
 export const MULTICALL_ADDRESS = '0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696'; // applies to mainnet, rinkeby, goerli, ropsten, kovan
-
 export const MULTICALL_ABI = [
   'function getCurrentBlockTimestamp() view returns (uint256 timestamp)',
   'function aggregate(tuple(address target, bytes callData)[] calls) view returns (uint256 blockNumber, bytes[] returnData)',
@@ -16,3 +15,7 @@ export const MULTICALL_ABI = [
   'function tryAggregate(bool requireSuccess, tuple(address target, bytes callData)[] calls) public view returns (tuple(bool success, bytes returnData)[] returnData)',
   'function tryBlockAndAggregate(bool requireSuccess, tuple(address target, bytes callData)[] calls) public view returns (uint256 blockNumber, bytes32 blockHash, tuple(bool success, bytes returnData)[] returnData)',
 ];
+
+// Data for Grants contracts
+export const GRANT_REGISTRY_ADDRESS = '0x70e0bA845a1A0F2DA3359C97E0285013525FFC49';
+export { abi as GRANT_REGISTRY_ABI } from '@dgrants/contracts/artifacts/contracts/GrantRegistry.sol/GrantRegistry.json';

--- a/app/src/utils/constants.ts
+++ b/app/src/utils/constants.ts
@@ -3,6 +3,7 @@ export const RPC_URL = `https://mainnet.infura.io/v3/${import.meta.env.VITE_INFU
 
 // Read data using Multicall2: https://github.com/makerdao/multicall
 export const MULTICALL_ADDRESS = '0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696'; // applies to mainnet, rinkeby, goerli, ropsten, kovan
+
 export const MULTICALL_ABI = [
   'function getCurrentBlockTimestamp() view returns (uint256 timestamp)',
   'function aggregate(tuple(address target, bytes callData)[] calls) view returns (uint256 blockNumber, bytes[] returnData)',

--- a/app/src/utils/constants.ts
+++ b/app/src/utils/constants.ts
@@ -1,5 +1,5 @@
 // Default RPC URL when user does not have a wallet connected
-export const RPC_URL = `https://mainnet.infura.io/v3/${import.meta.env.VITE_INFURA_API_KEY}`;
+export const RPC_URL = `https://mainnet.infura.io/v3/${import.meta.env.VITE_INFURA_ID}`;
 
 // Read data using Multicall2: https://github.com/makerdao/multicall
 export const MULTICALL_ADDRESS = '0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696'; // applies to mainnet, rinkeby, goerli, ropsten, kovan

--- a/app/src/utils/ethers.ts
+++ b/app/src/utils/ethers.ts
@@ -18,6 +18,7 @@
 export { getAddress, isAddress } from '@ethersproject/address';
 export { BigNumber } from '@ethersproject/bignumber';
 export { Contract } from '@ethersproject/contracts';
+export type { ContractTransaction } from '@ethersproject/contracts';
 export type { Network } from '@ethersproject/networks';
 export { JsonRpcProvider, JsonRpcSigner, Web3Provider } from '@ethersproject/providers';
 export { commify, formatUnits } from '@ethersproject/units';

--- a/app/src/utils/ethers.ts
+++ b/app/src/utils/ethers.ts
@@ -15,7 +15,7 @@
  * Read more at https://github.com/vitejs/vite/issues/731
  */
 
-export { getAddress } from '@ethersproject/address';
+export { getAddress, isAddress } from '@ethersproject/address';
 export { BigNumber } from '@ethersproject/bignumber';
 export { Contract } from '@ethersproject/contracts';
 export type { Network } from '@ethersproject/networks';

--- a/app/src/utils/formatters.ts
+++ b/app/src/utils/formatters.ts
@@ -1,9 +1,0 @@
-/**
- * @notice Various formatters to help display data in the UI nicely
- */
-
-// Returns an address with the following format: 0x1234...abcd
-export function formatAddress(address: string) {
-  if (address.length !== 42) return null;
-  return `${address.slice(0, 6)}...${address.slice(38)}`;
-}

--- a/app/src/utils/utils.ts
+++ b/app/src/utils/utils.ts
@@ -2,6 +2,7 @@
  * @notice Various helper methods and formatters to help display data in the UI nicely
  */
 import router from 'src/router/index';
+import { RouteLocationRaw } from 'vue-router';
 
 // Returns an address with the following format: 0x1234...abcd
 export function formatAddress(address: string) {
@@ -9,7 +10,7 @@ export function formatAddress(address: string) {
   return `${address.slice(0, 6)}...${address.slice(38)}`;
 }
 
-// Navigates to the page named `name` and pushes a new entry into the history stack
-export async function pushRoute(name: string) {
-  await router.push({ name });
+// Navigates to the specified page and pushes a new entry into the history stack
+export async function pushRoute(to: RouteLocationRaw) {
+  await router.push(to);
 }

--- a/app/src/utils/utils.ts
+++ b/app/src/utils/utils.ts
@@ -1,0 +1,15 @@
+/**
+ * @notice Various helper methods and formatters to help display data in the UI nicely
+ */
+import router from 'src/router/index';
+
+// Returns an address with the following format: 0x1234...abcd
+export function formatAddress(address: string) {
+  if (address.length !== 42) return null;
+  return `${address.slice(0, 6)}...${address.slice(38)}`;
+}
+
+// Navigates to the page named `name` and pushes a new entry into the history stack
+export async function pushRoute(name: string) {
+  await router.push({ name });
+}

--- a/app/src/utils/utils.ts
+++ b/app/src/utils/utils.ts
@@ -3,6 +3,7 @@
  */
 import router from 'src/router/index';
 import { RouteLocationRaw } from 'vue-router';
+import { isAddress } from 'src/utils/ethers';
 
 // Returns an address with the following format: 0x1234...abcd
 export function formatAddress(address: string) {
@@ -13,4 +14,14 @@ export function formatAddress(address: string) {
 // Navigates to the specified page and pushes a new entry into the history stack
 export async function pushRoute(to: RouteLocationRaw) {
   await router.push(to);
+}
+
+// Returns true if the provided URL is a valid URL
+export function isValidUrl(val: string) {
+  return val && val.includes('://'); // TODO more robust URL validation
+}
+
+// Returns true if the provided address is valid (TODO support ENS)
+export function isValidAddress(val: string) {
+  return isAddress(val);
 }

--- a/app/src/views/GrantRegistryGrantDetail.vue
+++ b/app/src/views/GrantRegistryGrantDetail.vue
@@ -23,7 +23,7 @@
     </div>
 
     <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md text-left">
-      <div class="py-8 px-4 border shadow sm:rounded-lg sm:px-6">
+      <div class="py-8 px-4 border border-gray-200 shadow sm:rounded-lg sm:px-6 bg-gray-50">
         <form class="space-y-6" @submit.prevent="saveEdits">
           <!-- Owner address -->
           <BaseInput

--- a/app/src/views/GrantRegistryGrantDetail.vue
+++ b/app/src/views/GrantRegistryGrantDetail.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>Grant Registry Grant Detail</div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'GrantRegistryGrantDetail',
+});
+</script>

--- a/app/src/views/GrantRegistryGrantDetail.vue
+++ b/app/src/views/GrantRegistryGrantDetail.vue
@@ -1,11 +1,23 @@
 <template>
-  <div>Grant Registry Grant Detail</div>
+  <div class="font-bold">Details for Grant ID {{ grant.id.toString() }}</div>
+  <p>Owner: {{ grant.owner }}</p>
+  <p>Payee: {{ grant.payee }}</p>
+  <p>
+    Metadata URL: <a class="link" :href="grant.metaPtr" target="_blank">{{ grant.metaPtr }}</a>
+  </p>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { useRoute } from 'vue-router';
+import useDataStore from 'src/store/data';
 
 export default defineComponent({
   name: 'GrantRegistryGrantDetail',
+  setup() {
+    const route = useRoute();
+    const { grants } = useDataStore();
+    return { grant: grants.value[route.params.id] };
+  },
 });
 </script>

--- a/app/src/views/GrantRegistryGrantDetail.vue
+++ b/app/src/views/GrantRegistryGrantDetail.vue
@@ -1,23 +1,156 @@
 <template>
-  <div class="font-bold">Details for Grant ID {{ grant.id.toString() }}</div>
-  <p>Owner: {{ grant.owner }}</p>
-  <p>Payee: {{ grant.payee }}</p>
-  <p>
-    Metadata URL: <a class="link" :href="grant.metaPtr" target="_blank">{{ grant.metaPtr }}</a>
-  </p>
+  <!-- Grant details -->
+  <div v-if="!isEditing">
+    <div class="font-bold">Details for Grant ID {{ grant.id.toString() }}</div>
+    <p>Owner: {{ grant.owner }}</p>
+    <p>Payee: {{ grant.payee }}</p>
+    <p>
+      Metadata URL: <a class="link" :href="grant.metaPtr" target="_blank">{{ grant.metaPtr }}</a>
+    </p>
+
+    <button v-if="isOwner" @click="isEditing = true" class="mt-5 btn btn-primary">Edit Grant</button>
+  </div>
+
+  <!-- Editing grant -->
+  <div v-else class="flex flex-col justify-center sm:px-6 lg:px-8">
+    <div class="sm:mx-auto sm:w-full sm:max-w-md">
+      <img
+        class="mx-auto h-12 w-auto"
+        src="https://tailwindui.com/img/logos/workflow-mark-indigo-600.svg"
+        alt="Workflow"
+      />
+      <h2 class="mt-6 text-center text-3xl font-extrabold text-gray-900">Edit Grant {{ grant.id.toString() }}</h2>
+    </div>
+
+    <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md text-left">
+      <div class="py-8 px-4 border shadow sm:rounded-lg sm:px-6">
+        <form class="space-y-6" @submit.prevent="saveEdits">
+          <!-- Owner address -->
+          <BaseInput
+            v-model="form.owner"
+            description="The owner has permission to edit the grant"
+            id="owner-address"
+            label="Owner address"
+            :rules="isValidAddress"
+            errorMsg="Please enter a valid address"
+          />
+
+          <!-- Payee address -->
+          <BaseInput
+            v-model="form.payee"
+            description="The address contributions and matching funds are sent to"
+            id="payee-address"
+            label="Payee address"
+            :rules="isValidAddress"
+            errorMsg="Please enter a valid address"
+          />
+
+          <!-- Metadata pointer -->
+          <BaseInput
+            v-model="form.metaPtr"
+            description="URL containing additional details about this grant"
+            id="metadata-url"
+            label="Metadata URL"
+            :rules="isValidUrl"
+            errorMsg="Please enter a valid URL"
+          />
+
+          <!-- Submit and cancel buttons -->
+          <button
+            type="submit"
+            class="btn btn-primary w-full"
+            :class="{ 'btn-primary-disabled': !isFormValid }"
+            :disabled="!isFormValid"
+          >
+            Save Edits
+          </button>
+          <button @click.prevent="cancelEdits" class="btn btn-outline w-full">Cancel</button>
+        </form>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { computed, defineComponent, ref } from 'vue';
 import { useRoute } from 'vue-router';
+import BaseInput from 'src/components/BaseInput.vue';
+// --- Store ---
 import useDataStore from 'src/store/data';
+import useWalletStore from 'src/store/wallet';
+// --- Methods and Data ---
+import { GRANT_REGISTRY_ADDRESS, GRANT_REGISTRY_ABI } from 'src/utils/constants';
+import { Contract, ContractTransaction } from 'src/utils/ethers';
+import { isValidAddress, isValidUrl } from 'src/utils/utils';
+// --- Types ---
+import { GrantRegistry } from '@dgrants/contracts';
+
+function useGrantDetail() {
+  const { grants, poll } = useDataStore();
+  const { signer, userAddress } = useWalletStore();
+
+  const route = useRoute();
+  const grant = computed(() => grants.value[route.params.id]);
+
+  // --- Edit capabilities ---
+  const isOwner = computed(() => userAddress.value === grant.value.owner);
+  const isEditing = ref(false);
+  const form = ref<{ owner: string | undefined; payee: string | undefined; metaPtr: string | undefined }>({
+    owner: grant.value.owner,
+    payee: grant.value.payee,
+    metaPtr: grant.value.metaPtr,
+  });
+  const isFormValid = computed(() => {
+    const { owner, payee, metaPtr } = form.value;
+    const areFieldsValid = isValidAddress(owner) && isValidAddress(payee) && isValidUrl(metaPtr);
+    const areFieldsUpdated = owner !== grant.value.owner || payee !== grant.value.payee || metaPtr !== grant.value.metaPtr; // prettier-ignore
+    return areFieldsValid && areFieldsUpdated;
+  });
+
+  /**
+   * @notice Resets the form values that user may have changed, and hides the edit window
+   */
+  function cancelEdits() {
+    ['owner', 'payee', 'metaPtr'].forEach((field) => (form.value[field] = grant.value[field])); // reset form values
+    isEditing.value = false; // hide edit form
+  }
+
+  /**
+   * @notice Saves edits
+   */
+  async function saveEdits() {
+    // Get contract instance
+    if (!signer.value) throw new Error('Please connect a wallet');
+    const { owner, payee, metaPtr } = form.value;
+    const registry = <GrantRegistry>new Contract(GRANT_REGISTRY_ADDRESS, GRANT_REGISTRY_ABI, signer.value);
+
+    // Determine which update method to call
+    let tx: ContractTransaction;
+    const g = grant.value; // for better readability in the if statements
+    if (owner !== g.owner && payee === g.payee && metaPtr === g.metaPtr) {
+      tx = await registry.updateGrantOwner(g.id, owner);
+    } else if (owner === g.owner && payee !== g.payee && metaPtr === g.metaPtr) {
+      tx = await registry.updateGrantPayee(g.id, payee);
+    } else if (owner === g.owner && payee === g.payee && metaPtr !== g.metaPtr) {
+      tx = await registry.updateGrantMetaPtr(g.id, metaPtr);
+    } else {
+      tx = await registry.updateGrant(g.id, owner, payee, metaPtr);
+    }
+
+    // After tx mines, poll so the store has the latest data, then navigate to the grant page
+    await tx.wait();
+    await poll();
+    cancelEdits(); // reset form ref and toggle page state back to display mode
+  }
+
+  return { isEditing, isOwner, isValidAddress, isValidUrl, isFormValid, grant, form, cancelEdits, saveEdits };
+}
 
 export default defineComponent({
   name: 'GrantRegistryGrantDetail',
+  components: { BaseInput },
   setup() {
-    const route = useRoute();
-    const { grants } = useDataStore();
-    return { grant: grants.value[route.params.id] };
+    return { ...useGrantDetail() };
   },
 });
 </script>

--- a/app/src/views/GrantRegistryList.vue
+++ b/app/src/views/GrantRegistryList.vue
@@ -1,63 +1,64 @@
 <template>
-  <!-- Create New Grant -->
-  <!-- Create New Grant -->
-  <div class="mb-10">
-    <h1 class="text-lg mb-3">Create New Grant</h1>
-    <div class="mb-1">Click the button below to create a new grant</div>
-    <button @click="pushRoute({ name: 'dgrants-new' })" class="btn btn-secondary">Create Grant</button>
-  </div>
+  <div class="max-w-screen-lg mx-auto">
+    <!-- Create New Grant -->
+    <div class="mb-10">
+      <h1 class="text-lg mb-3">Create New Grant</h1>
+      <div class="mb-1">Click the button below to create a new grant</div>
+      <button @click="pushRoute({ name: 'dgrants-new' })" class="btn btn-secondary">Create Grant</button>
+    </div>
 
-  <!-- View Existing Grants -->
-  <h1 class="text-lg mb-3">Grant Registry List</h1>
-  <div class="mb-1">Below is all grants read from the GrantRegistry contract</div>
-  <ul class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-    <li
-      v-for="grant in grants"
-      :key="grant.id"
-      @click="pushRoute({ name: 'dgrants-id', params: { id: grant.id } })"
-      class="
-        col-span-1
-        bg-white
-        rounded-lg
-        shadow
-        divide-y divide-gray-200
-        cursor-pointer
-        border
-        hover:border-primary-500
-      "
-    >
-      <div class="w-full flex items-center justify-between p-6 space-x-6 hover:border">
-        <div class="flex-1 truncate text-left">
-          <div class="flex items-center space-x-3">
-            <h3 class="text-gray-900 text-sm font-medium truncate">Grant ID: {{ grant.id.toString() }}</h3>
-          </div>
-          <p class="mt-1 text-gray-500 text-sm truncate">{{ grant.metaPtr }}</p>
-        </div>
-      </div>
-      <div>
-        <div class="pl-6 p-2 -mt-px flex divide-x divide-gray-200">
-          <div class="w-0 flex-1 flex">
-            <div class="flex-1 truncate text-left">
-              <p class="mt-1 text-gray-500 text-sm truncate">Owner</p>
-              <div class="flex items-center space-x-3">
-                <h3 class="text-gray-900 text-sm font-medium">{{ formatAddress(grant.owner) }}</h3>
-              </div>
+    <!-- View Existing Grants -->
+    <h1 class="text-lg mb-3">Grant Registry List</h1>
+    <div class="mb-1">Below is all grants read from the GrantRegistry contract</div>
+    <ul class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      <li
+        v-for="grant in grants"
+        :key="grant.id"
+        @click="pushRoute({ name: 'dgrants-id', params: { id: grant.id } })"
+        class="
+          col-span-1
+          bg-white
+          rounded-lg
+          shadow
+          divide-y divide-gray-200
+          cursor-pointer
+          border
+          hover:border-primary-500
+        "
+      >
+        <div class="w-full flex items-center justify-between p-6 space-x-6 hover:border">
+          <div class="flex-1 truncate text-left">
+            <div class="flex items-center space-x-3">
+              <h3 class="text-gray-900 text-sm font-medium truncate">Grant ID: {{ grant.id.toString() }}</h3>
             </div>
+            <p class="mt-1 text-gray-500 text-sm truncate">{{ grant.metaPtr }}</p>
           </div>
-          <div class="pl-6 -ml-px w-0 flex-1 flex">
+        </div>
+        <div>
+          <div class="pl-6 p-2 -mt-px flex divide-x divide-gray-200">
             <div class="w-0 flex-1 flex">
               <div class="flex-1 truncate text-left">
-                <p class="mt-1 text-gray-500 text-sm truncate">Payee</p>
+                <p class="mt-1 text-gray-500 text-sm truncate">Owner</p>
                 <div class="flex items-center space-x-3">
-                  <h3 class="text-gray-900 text-sm font-medium">{{ formatAddress(grant.payee) }}</h3>
+                  <h3 class="text-gray-900 text-sm font-medium">{{ formatAddress(grant.owner) }}</h3>
+                </div>
+              </div>
+            </div>
+            <div class="pl-6 -ml-px w-0 flex-1 flex">
+              <div class="w-0 flex-1 flex">
+                <div class="flex-1 truncate text-left">
+                  <p class="mt-1 text-gray-500 text-sm truncate">Payee</p>
+                  <div class="flex items-center space-x-3">
+                    <h3 class="text-gray-900 text-sm font-medium">{{ formatAddress(grant.payee) }}</h3>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-    </li>
-  </ul>
+      </li>
+    </ul>
+  </div>
 </template>
 
 <script lang="ts">

--- a/app/src/views/GrantRegistryList.vue
+++ b/app/src/views/GrantRegistryList.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>Grant Registry List</div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'GrantRegistryList',
+});
+</script>

--- a/app/src/views/GrantRegistryList.vue
+++ b/app/src/views/GrantRegistryList.vue
@@ -1,11 +1,51 @@
 <template>
-  <div>Grant Registry List</div>
+  <h1 class="text-lg mb-3">Grant Registry List</h1>
+  <ul class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+    <li v-for="grant in grants" :key="grant.id" class="col-span-1 bg-white rounded-lg shadow divide-y divide-gray-200">
+      <div class="w-full flex items-center justify-between p-6 space-x-6">
+        <div class="flex-1 truncate text-left">
+          <div class="flex items-center space-x-3">
+            <h3 class="text-gray-900 text-sm font-medium truncate">Grant ID: {{ grant.id.toString() }}</h3>
+          </div>
+          <p class="mt-1 text-gray-500 text-sm truncate">{{ grant.metaPtr }}</p>
+        </div>
+      </div>
+      <div>
+        <div class="pl-6 p-2 -mt-px flex divide-x divide-gray-200">
+          <div class="w-0 flex-1 flex">
+            <div class="flex-1 truncate text-left">
+              <p class="mt-1 text-gray-500 text-sm truncate">Owner</p>
+              <div class="flex items-center space-x-3">
+                <h3 class="text-gray-900 text-sm font-medium">{{ formatAddress(grant.owner) }}</h3>
+              </div>
+            </div>
+          </div>
+          <div class="pl-6 -ml-px w-0 flex-1 flex">
+            <div class="w-0 flex-1 flex">
+              <div class="flex-1 truncate text-left">
+                <p class="mt-1 text-gray-500 text-sm truncate">Payee</p>
+                <div class="flex items-center space-x-3">
+                  <h3 class="text-gray-900 text-sm font-medium">{{ formatAddress(grant.payee) }}</h3>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+  </ul>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { formatAddress } from 'src/utils/formatters';
+import useDataStore from 'src/store/data';
 
 export default defineComponent({
   name: 'GrantRegistryList',
+  setup() {
+    const { grants } = useDataStore();
+    return { formatAddress, grants };
+  },
 });
 </script>

--- a/app/src/views/GrantRegistryList.vue
+++ b/app/src/views/GrantRegistryList.vue
@@ -20,9 +20,9 @@
           bg-white
           rounded-lg
           shadow
-          divide-y divide-gray-200
+          divide-y divide-gray-400 divide-opacity-30
           cursor-pointer
-          border
+          border border-gray-200
           hover:border-primary-500
         "
       >
@@ -35,7 +35,7 @@
           </div>
         </div>
         <div>
-          <div class="pl-6 p-2 -mt-px flex divide-x divide-gray-200">
+          <div class="pl-6 p-2 -mt-px flex divide-x divide-gray-400 divide-opacity-30">
             <div class="w-0 flex-1 flex">
               <div class="flex-1 truncate text-left">
                 <p class="mt-1 text-gray-500 text-sm truncate">Owner</p>

--- a/app/src/views/GrantRegistryList.vue
+++ b/app/src/views/GrantRegistryList.vue
@@ -1,5 +1,14 @@
 <template>
+  <!-- Create New Grant -->
+  <!-- Create New Grant -->
+  <div class="mb-10">
+    <h1 class="text-lg mb-3">Create New Grant</h1>
+    <div class="mb-1">Click the button below to create a new grant</div>
+    <button @click="pushRoute('dgrants-new')" class="btn btn-secondary">Create Grant</button>
+  </div>
+  <!-- View Existing Grants -->
   <h1 class="text-lg mb-3">Grant Registry List</h1>
+  <div class="mb-1">Below is all grants read from the GrantRegistry contract</div>
   <ul class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
     <li v-for="grant in grants" :key="grant.id" class="col-span-1 bg-white rounded-lg shadow divide-y divide-gray-200">
       <div class="w-full flex items-center justify-between p-6 space-x-6">
@@ -38,14 +47,14 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { formatAddress } from 'src/utils/formatters';
+import { formatAddress, pushRoute } from 'src/utils/utils';
 import useDataStore from 'src/store/data';
 
 export default defineComponent({
   name: 'GrantRegistryList',
   setup() {
     const { grants } = useDataStore();
-    return { formatAddress, grants };
+    return { formatAddress, pushRoute, grants };
   },
 });
 </script>

--- a/app/src/views/GrantRegistryList.vue
+++ b/app/src/views/GrantRegistryList.vue
@@ -4,14 +4,29 @@
   <div class="mb-10">
     <h1 class="text-lg mb-3">Create New Grant</h1>
     <div class="mb-1">Click the button below to create a new grant</div>
-    <button @click="pushRoute('dgrants-new')" class="btn btn-secondary">Create Grant</button>
+    <button @click="pushRoute({ name: 'dgrants-new' })" class="btn btn-secondary">Create Grant</button>
   </div>
+
   <!-- View Existing Grants -->
   <h1 class="text-lg mb-3">Grant Registry List</h1>
   <div class="mb-1">Below is all grants read from the GrantRegistry contract</div>
   <ul class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-    <li v-for="grant in grants" :key="grant.id" class="col-span-1 bg-white rounded-lg shadow divide-y divide-gray-200">
-      <div class="w-full flex items-center justify-between p-6 space-x-6">
+    <li
+      v-for="grant in grants"
+      :key="grant.id"
+      @click="pushRoute({ name: 'dgrants-id', params: { id: grant.id } })"
+      class="
+        col-span-1
+        bg-white
+        rounded-lg
+        shadow
+        divide-y divide-gray-200
+        cursor-pointer
+        border
+        hover:border-primary-500
+      "
+    >
+      <div class="w-full flex items-center justify-between p-6 space-x-6 hover:border">
         <div class="flex-1 truncate text-left">
           <div class="flex items-center space-x-3">
             <h3 class="text-gray-900 text-sm font-medium truncate">Grant ID: {{ grant.id.toString() }}</h3>

--- a/app/src/views/GrantRegistryNewGrant.vue
+++ b/app/src/views/GrantRegistryNewGrant.vue
@@ -1,5 +1,48 @@
 <template>
-  <div>Grant Registry New Grant</div>
+  <div class="flex flex-col justify-center sm:px-6 lg:px-8">
+    <div class="sm:mx-auto sm:w-full sm:max-w-md">
+      <img
+        class="mx-auto h-12 w-auto"
+        src="https://tailwindui.com/img/logos/workflow-mark-indigo-600.svg"
+        alt="Workflow"
+      />
+      <h2 class="mt-6 text-center text-3xl font-extrabold text-gray-900">Create New Grant</h2>
+    </div>
+
+    <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md text-left">
+      <div class="py-8 px-4 border shadow sm:rounded-lg sm:px-6">
+        <form class="space-y-6" action="#" method="POST">
+          <div>
+            <label for="owner" class="block text-sm font-medium text-gray-700"> Owner address </label>
+            <p class="text-gray-500 text-sm">The owner has permission to edit the grant</p>
+            <div class="mt-1">
+              <input id="owner" name="owner" type="owner" required class="input" />
+            </div>
+          </div>
+
+          <div>
+            <label for="payee" class="block text-sm font-medium text-gray-700"> Payee address </label>
+            <p class="text-gray-500 text-sm">The address contributions and matching funds are sent to</p>
+            <div class="mt-1">
+              <input id="payee" name="payee" type="payee" required class="input" />
+            </div>
+          </div>
+
+          <div>
+            <label for="metadataUrl" class="block text-sm font-medium text-gray-700"> Metadata URL </label>
+            <p class="text-gray-500 text-sm">URL containing additional details about this grant</p>
+            <div class="mt-1">
+              <input id="metadataUrl" name="metadataUrl" type="metadataUrl" required class="input" />
+            </div>
+          </div>
+
+          <div>
+            <button type="submit" class="btn btn-primary w-full">Create Grant</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script lang="ts">

--- a/app/src/views/GrantRegistryNewGrant.vue
+++ b/app/src/views/GrantRegistryNewGrant.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>Grant Registry New Grant</div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'GrantRegistryNewGrant',
+});
+</script>

--- a/app/src/views/GrantRegistryNewGrant.vue
+++ b/app/src/views/GrantRegistryNewGrant.vue
@@ -12,33 +12,35 @@
     <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md text-left">
       <div class="py-8 px-4 border shadow sm:rounded-lg sm:px-6">
         <form class="space-y-6" action="#" method="POST">
-          <div>
-            <label for="owner" class="block text-sm font-medium text-gray-700"> Owner address </label>
-            <p class="text-gray-500 text-sm">The owner has permission to edit the grant</p>
-            <div class="mt-1">
-              <input id="owner" name="owner" type="owner" required class="input" />
-            </div>
-          </div>
+          <!-- Owner address -->
+          <BaseInput
+            v-model="owner"
+            description="The owner has permission to edit the grant"
+            id="owner-address"
+            label="Owner address"
+            errorMsg="Please enter a valid address"
+          />
 
-          <div>
-            <label for="payee" class="block text-sm font-medium text-gray-700"> Payee address </label>
-            <p class="text-gray-500 text-sm">The address contributions and matching funds are sent to</p>
-            <div class="mt-1">
-              <input id="payee" name="payee" type="payee" required class="input" />
-            </div>
-          </div>
+          <!-- Payee address -->
+          <BaseInput
+            v-model="payee"
+            description="The address contributions and matching funds are sent to"
+            id="payee-address"
+            label="Payee address"
+            errorMsg="Please enter a valid address"
+          />
 
-          <div>
-            <label for="metadataUrl" class="block text-sm font-medium text-gray-700"> Metadata URL </label>
-            <p class="text-gray-500 text-sm">URL containing additional details about this grant</p>
-            <div class="mt-1">
-              <input id="metadataUrl" name="metadataUrl" type="metadataUrl" required class="input" />
-            </div>
-          </div>
+          <!-- Metadata pointer -->
+          <BaseInput
+            v-model="metaPtr"
+            description="URL containing additional details about this grant"
+            id="metadata-url"
+            label="Metadata URL"
+            errorMsg="Please enter a valid URL"
+          />
 
-          <div>
-            <button type="submit" class="btn btn-primary w-full">Create Grant</button>
-          </div>
+          <!-- Submit button -->
+          <button type="submit" class="btn btn-primary w-full">Create Grant</button>
         </form>
       </div>
     </div>
@@ -46,9 +48,18 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, ref } from 'vue';
+import BaseInput from 'src/components/BaseInput.vue';
 
 export default defineComponent({
   name: 'GrantRegistryNewGrant',
+  components: { BaseInput },
+  setup() {
+    const isOwnerValid = ref(false);
+    const owner = ref();
+    const payee = ref();
+    const metaPtr = ref();
+    return { isOwnerValid, owner, payee, metaPtr };
+  },
 });
 </script>

--- a/app/src/views/GrantRegistryNewGrant.vue
+++ b/app/src/views/GrantRegistryNewGrant.vue
@@ -10,7 +10,7 @@
     </div>
 
     <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md text-left">
-      <div class="py-8 px-4 border shadow sm:rounded-lg sm:px-6">
+      <div class="py-8 px-4 border border-gray-200 shadow sm:rounded-lg sm:px-6 bg-gray-50">
         <form class="space-y-6" @submit.prevent="createGrant">
           <!-- Owner address -->
           <BaseInput

--- a/app/src/views/Home.vue
+++ b/app/src/views/Home.vue
@@ -4,7 +4,6 @@
   <div v-if="userDisplayName">
     <div>Block number: {{ blockNumber }}</div>
     <div>Date: {{ date }}</div>
-    <div>Balance: {{ balance }} ETH</div>
   </div>
 
   <div class="mt-3">
@@ -29,13 +28,12 @@ export default defineComponent({
       router.push({ name });
     }
 
-    const { lastBlockNumber, lastBlockTimestamp, ethBalance } = useDataStore();
+    const { lastBlockNumber, lastBlockTimestamp } = useDataStore();
     const { userDisplayName, network } = useWalletStore();
 
     const blockNumber = computed(() => commify(lastBlockNumber.value));
     const date = computed(() => new Date(lastBlockTimestamp.value * 1000).toLocaleString());
-    const balance = computed(() => (ethBalance.value ? Number(formatUnits(ethBalance.value)).toFixed(4) : 0));
-    return { push, userDisplayName, network, blockNumber, date, balance, formatUnits };
+    return { push, userDisplayName, network, blockNumber, date, formatUnits };
   },
 });
 </script>

--- a/app/src/views/Home.vue
+++ b/app/src/views/Home.vue
@@ -7,7 +7,7 @@
   </div>
 
   <div class="mt-3">
-    <button @click="pushRoute('dgrants')" class="btn btn-primary mr-3">Grants Registry</button>
+    <button @click="pushRoute({ name: 'dgrants' })" class="btn btn-primary mr-3">Grants Registry</button>
   </div>
 </template>
 

--- a/app/src/views/Home.vue
+++ b/app/src/views/Home.vue
@@ -6,6 +6,11 @@
     <div>Date: {{ date }}</div>
     <div>Balance: {{ balance }} ETH</div>
   </div>
+
+  <div class="mt-3">
+    <button @click="push('dgrants')" class="btn btn-primary mr-3">Grants Registry</button>
+    <button @click="push('dgrants-new')" class="btn btn-secondary">Create New Grant</button>
+  </div>
 </template>
 
 <script lang="ts">
@@ -13,17 +18,24 @@ import { computed, defineComponent } from 'vue';
 import useDataStore from 'src/store/data';
 import useWalletStore from 'src/store/wallet';
 import { commify, formatUnits } from 'src/utils/ethers';
+import { useRouter } from 'vue-router';
 
 export default defineComponent({
   name: 'Home',
   setup() {
+    // Router navigation
+    const router = useRouter();
+    function push(name: string) {
+      router.push({ name });
+    }
+
     const { lastBlockNumber, lastBlockTimestamp, ethBalance } = useDataStore();
     const { userDisplayName, network } = useWalletStore();
 
     const blockNumber = computed(() => commify(lastBlockNumber.value));
     const date = computed(() => new Date(lastBlockTimestamp.value * 1000).toLocaleString());
     const balance = computed(() => (ethBalance.value ? Number(formatUnits(ethBalance.value)).toFixed(4) : 0));
-    return { userDisplayName, network, blockNumber, date, balance, formatUnits };
+    return { push, userDisplayName, network, blockNumber, date, balance, formatUnits };
   },
 });
 </script>

--- a/app/src/views/Home.vue
+++ b/app/src/views/Home.vue
@@ -7,8 +7,7 @@
   </div>
 
   <div class="mt-3">
-    <button @click="push('dgrants')" class="btn btn-primary mr-3">Grants Registry</button>
-    <button @click="push('dgrants-new')" class="btn btn-secondary">Create New Grant</button>
+    <button @click="pushRoute('dgrants')" class="btn btn-primary mr-3">Grants Registry</button>
   </div>
 </template>
 
@@ -17,23 +16,17 @@ import { computed, defineComponent } from 'vue';
 import useDataStore from 'src/store/data';
 import useWalletStore from 'src/store/wallet';
 import { commify, formatUnits } from 'src/utils/ethers';
-import { useRouter } from 'vue-router';
+import { pushRoute } from 'src/utils/utils';
 
 export default defineComponent({
   name: 'Home',
   setup() {
-    // Router navigation
-    const router = useRouter();
-    function push(name: string) {
-      router.push({ name });
-    }
-
     const { lastBlockNumber, lastBlockTimestamp } = useDataStore();
     const { userDisplayName, network } = useWalletStore();
 
     const blockNumber = computed(() => commify(lastBlockNumber.value));
     const date = computed(() => new Date(lastBlockTimestamp.value * 1000).toLocaleString());
-    return { push, userDisplayName, network, blockNumber, date, formatUnits };
+    return { formatUnits, pushRoute, blockNumber, date, network, userDisplayName };
   },
 });
 </script>

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -15,5 +15,5 @@ module.exports = {
   variants: {
     extend: {},
   },
-  plugins: [require('nightwind')],
+  plugins: [require('@tailwindcss/forms'), require('nightwind')],
 };

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -11,6 +11,15 @@ module.exports = {
         secondary: colors.yellow, // secondary theme color
       },
     },
+    nightwind: {
+      // Keys specify light-mode colors, and values are overrides for Nightwind to replace them with
+      colors: {
+        white: 'gray.900',
+        gray: {
+          50: 'gray.800',
+        },
+      },
+    },
   },
   variants: {
     extend: {},

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -58,7 +58,9 @@
     "precommit": "lint-staged",
     "prettier": "prettier --write \"**/*.{js,json,md,sol,ts}\"",
     "test": "hardhat test",
-    "typechain": "hardhat typechain"
+    "typechain": "hardhat typechain",
+    "app:node": "hardhat node",
+    "app:setup": "hardhat run scripts/app.ts --network localhost"
   },
   "volta": {
     "extends": "../package.json"

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -59,7 +59,7 @@
     "prettier": "prettier --write \"**/*.{js,json,md,sol,ts}\"",
     "test": "hardhat test",
     "typechain": "hardhat typechain",
-    "app:node": "hardhat node",
+    "app:node": "INFURA_ID=$(grep INFURA_ID .env | cut -d '=' -f2) && yarn hardhat node --fork \"https://mainnet.infura.io/v3/$INFURA_ID\"",
     "app:setup": "hardhat run scripts/app.ts --network localhost"
   },
   "volta": {

--- a/contracts/scripts/app.ts
+++ b/contracts/scripts/app.ts
@@ -1,0 +1,59 @@
+/**
+ * @notice Deploys an instance of the GrantRegistry and initialize is with dummy data
+ * @dev Used for testing the UI
+ * @dev To ensure the GrantRegistry deploys to the expected address, make sure your mnemonic is set to the Hardhat
+ * default mnemonic of `test test test test test test test test test test test junk`. When set correctly, the
+ * GrantRegistry contract should be deployed locally to 0x5FbDB2315678afecb367f032d93F642f64180aa3
+ */
+
+// --- External imports ---
+import { ContractFactory } from 'ethers';
+import { ethers, network } from 'hardhat';
+
+// --- Our imports ---
+import { GrantRegistry } from '../typechain/GrantRegistry';
+
+// --- Constants ---
+// Define grants to create (addresses are random)
+const grants = [
+  {
+    owner: '0x34f4E532a33EB545941e914B25Efe348Aea31f0A',
+    payee: '0x06c94663E5884BE4cCe85F0869e95C7712d34803',
+    metaPtr: 'https://invent-teleportation.eth.link',
+  },
+  {
+    owner: '0x58E52440F56f2A5307772Ec881BCEf2c15e988Ab',
+    payee: '0x6f02c37ea174DD05f20aC118da725ffa6A40B990',
+    metaPtr: 'https://get-to-mars.eth.link',
+  },
+  {
+    owner: '0x1fB6C46e6aDD95698352707D7f93a31030c80a0B',
+    payee: '0x834e659c6757E250db500fe869877311Bb552966',
+    metaPtr: 'https://time-travel.eth.link',
+  },
+];
+
+// --- Method to execute ---
+async function main(): Promise<void> {
+  // Only run on Hardhat network
+  if (network.name !== 'localhost') throw new Error('This script is for use with a running local node');
+
+  // Deploy contract
+  const GrantRegistryFactory: ContractFactory = await ethers.getContractFactory('GrantRegistry');
+  const registry = <GrantRegistry>await GrantRegistryFactory.deploy();
+  await registry.deployed();
+  console.log(`Deployed GrantRegistry to ${registry.address}`);
+
+  // Create the grants
+  await Promise.all(grants.map((grant) => registry.createGrant(grant.owner, grant.payee, grant.metaPtr)));
+  console.log(`Created ${grants.length} dummy grants`);
+  console.log('✅ Setup complete!');
+}
+
+// --- Execute main() ---
+void main()
+  .then(() => process.exit(0))
+  .catch((error: Error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/contracts/scripts/app.ts
+++ b/contracts/scripts/app.ts
@@ -10,9 +10,6 @@
 import { ContractFactory } from 'ethers';
 import { ethers, network } from 'hardhat';
 
-// --- Our imports ---
-import { GrantRegistry } from '../typechain/GrantRegistry';
-
 // --- Constants ---
 // Define grants to create (addresses are random)
 const grants = [
@@ -38,16 +35,16 @@ async function main(): Promise<void> {
   // Only run on Hardhat network
   if (network.name !== 'localhost') throw new Error('This script is for use with a running local node');
 
+  // --- GrantRegistry Setup ---
   // Deploy contract
-  const GrantRegistryFactory: ContractFactory = await ethers.getContractFactory('GrantRegistry');
-  const registry = <GrantRegistry>await GrantRegistryFactory.deploy();
-  await registry.deployed();
+  const [deployer] = await ethers.getSigners();
+  const GrantRegistryFactory: ContractFactory = await ethers.getContractFactory('GrantRegistry', deployer);
+  const registry = await (await GrantRegistryFactory.deploy()).deployed();
   console.log(`Deployed GrantRegistry to ${registry.address}`);
 
   // Create the grants
   await Promise.all(grants.map((grant) => registry.createGrant(grant.owner, grant.payee, grant.metaPtr)));
   console.log(`Created ${grants.length} dummy grants`);
-  console.log('✅ Setup complete!');
 }
 
 // --- Execute main() ---

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "lerna run build",
     "clean": "lerna run clean",
     "node": "yarn contracts app:node",
-    "dev": "concurrently --kill-others \"yarn run node\" \"yarn contracts app:setup && yarn app dev\"",
+    "dev": "concurrently --restart-tries 5 --kill-others \"yarn run node\" \"yarn contracts app:setup && yarn app dev\"",
     "lint": "lerna run lint",
     "prettier": "lerna run prettier",
     "prepare": "lerna run prepare && husky install",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "types"
   ],
   "devDependencies": {
+    "concurrently": "^6.2.0",
     "eslint": "^7.24.0",
     "eslint-config-prettier": "^8.2.0",
     "husky": "^7.0.0",
@@ -20,7 +21,8 @@
   "scripts": {
     "build": "lerna run build",
     "clean": "lerna run clean",
-    "dev": "lerna run dev",
+    "node": "yarn contracts app:node",
+    "dev": "concurrently --kill-others \"yarn run node\" \"yarn contracts app:setup && yarn app dev\"",
     "lint": "lerna run lint",
     "prettier": "lerna run prettier",
     "prepare": "lerna run prepare && husky install",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5694,6 +5694,21 @@ concat-stream@^2.0.0:
     readable-stream "^3.0.2"
     typedarray "^0.0.6"
 
+concurrently@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-6.2.0.tgz#587e2cb8afca7234172d8ea55176088632c4c56d"
+  integrity sha512-v9I4Y3wFoXCSY2L73yYgwA9ESrQMpRn80jMcqMgHx720Hecz2GZAvTI6bREVST6lkddNypDKRN22qhK0X8Y00g==
+  dependencies:
+    chalk "^4.1.0"
+    date-fns "^2.16.1"
+    lodash "^4.17.21"
+    read-pkg "^5.2.0"
+    rxjs "^6.6.3"
+    spawn-command "^0.0.2-1"
+    supports-color "^8.1.0"
+    tree-kill "^1.2.2"
+    yargs "^16.2.0"
+
 config-chain@^1.1.12:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.13.tgz#fad0795aa6a6cdaff9ed1b68e9dff94372c232f4"
@@ -6172,6 +6187,11 @@ data-urls@^2.0.0:
     abab "^2.0.3"
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
+
+date-fns@^2.16.1:
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
+  integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
 
 dateformat@^3.0.0:
   version "3.0.3"
@@ -15423,6 +15443,11 @@ space-separated-tokens@^1.1.4:
   resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz#85f32c3d10d9682007e917414ddc5c26d1aa6899"
   integrity sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==
 
+spawn-command@^0.0.2-1:
+  version "0.0.2-1"
+  resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2-1.tgz#62f5e9466981c1b796dc5929937e11c9c6921bd0"
+  integrity sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=
+
 spdx-correct@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.1.tgz#dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9"
@@ -15819,7 +15844,7 @@ supports-color@6.0.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@8.1.1, supports-color@^8.0.0, supports-color@^8.1.1:
+supports-color@8.1.1, supports-color@^8.0.0, supports-color@^8.1.0, supports-color@^8.1.1:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
@@ -16277,6 +16302,11 @@ tr46@^2.1.0:
   integrity sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==
   dependencies:
     punycode "^2.1.1"
+
+tree-kill@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
+  integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
 trezor-connect@^8.1.9:
   version "8.1.27"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2234,6 +2234,13 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@tailwindcss/forms@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/forms/-/forms-0.3.3.tgz#a29d22668804f3dae293dcadbef1aa6315c45b64"
+  integrity sha512-U8Fi/gq4mSuaLyLtFISwuDYzPB73YzgozjxOIHsK6NXgg/IWD1FLaHbFlWmurAMyy98O+ao74ksdQefsquBV1Q==
+  dependencies:
+    mini-svg-data-uri "^1.2.3"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -11953,6 +11960,11 @@ min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
+
+mini-svg-data-uri@^1.2.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/mini-svg-data-uri/-/mini-svg-data-uri-1.3.3.tgz#91d2c09f45e056e5e1043340b8b37ba7b50f4fac"
+  integrity sha512-+fA2oRcR1dJI/7ITmeQJDrYWks0wodlOz0pAEhKYJ2IVc1z0AnwJUsKY2fzFmPAM3Jo9J0rBx8JAA9QQSJ5PuA==
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Closes #11, closes #18

- Implements everything described in #11
- Setup script forks mainnet, deploys `GrantRegistry` and creates dummy grants with arbitrary data
- Read `app/README.md` for setup/troubleshooting instructions when testing against a forked Hardhat node
- Didn't focus on designs too much, just pulled and modified some Tailwind UI components (for example, edit page is basically a copy/paste of the New Grant page to save time for now)
- Wallet connection can be a bit flaky, so created #14 to track this