### PR TITLE
Bulk donation support

### DIFF
--- a/contracts/.solhint.json
+++ b/contracts/.solhint.json
@@ -2,7 +2,7 @@
   "extends": "solhint:recommended",
   "plugins": ["prettier"],
   "rules": {
-    "code-complexity": ["error", 7],
+    "code-complexity": ["error", 9],
     "compiler-version": ["error", "^0.8.0"],
     "const-name-snakecase": "off",
     "constructor-syntax": "error",
@@ -10,6 +10,7 @@
     "max-line-length": "off",
     "not-rely-on-time": "off",
     "prettier/prettier": ["error", { "endOfLine": "auto" }],
-    "reason-string": "off"
+    "reason-string": "off",
+    "reentrancy": "off"
   }
 }

--- a/contracts/contracts/GrantRoundManager.sol
+++ b/contracts/contracts/GrantRoundManager.sol
@@ -9,20 +9,12 @@ import "./GrantRegistry.sol";
 import "./GrantRound.sol";
 
 contract GrantRoundManager {
+  // --- Libraries ---
   using Address for address;
   using BytesLib for bytes;
   using SafeERC20 for IERC20;
 
-  /// @notice Donation inputs and Uniswap V3 swap inputs: https://docs.uniswap.org/protocol/guides/swaps/multihop-swaps
-  struct Donation {
-    uint96 grantId; // grant ID to which donation is being made
-    GrantRound[] rounds; // rounds against which the donation should be counted
-    bytes path; // swap path, or if user is providing donationToken, the address of the donationToken
-    uint256 deadline; // unix timestamp after which a swap will revert, i.e. swap must be executed before this
-    uint256 amountIn; // amount donated by the user
-    uint256 amountOutMinimum; // minimum amount to be returned after swap
-  }
-
+  // --- Data ---
   /// @notice Address of the GrantRegistry
   GrantRegistry public immutable registry;
 
@@ -32,21 +24,40 @@ contract GrantRoundManager {
   /// @notice Address of the ERC20 token in which donations are made
   IERC20 public immutable donationToken;
 
+  /// @notice Used during donations to temporarily store swap output amounts
+  mapping(IERC20 => uint256) internal swapOutputs;
+
   /// @notice WETH address
   address public constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
 
+  /// @notice Scale factor
+  uint256 internal constant WAD = 1e18;
+
+  /// @notice Defines the total `amount` of the specified `token` that needs to be swapped to `donationToken`. If
+  /// `path == donationToken`, no swap is required and we just transfer the tokens
+  struct SwapSummary {
+    address token;
+    uint256 amount;
+    uint256 amountOutMinimum; // minimum amount to be returned after swap
+    bytes path;
+  }
+
+  /// @notice Donation inputs and Uniswap V3 swap inputs: https://docs.uniswap.org/protocol/guides/swaps/multihop-swaps
+  struct Donation {
+    uint96 grantId; // grant ID to which donation is being made
+    IERC20 token; // address of the token to donate
+    uint256 ratio; // ratio of `token` to donate, specified as numerator where WAD = 1e18 = 100%
+    GrantRound[] rounds; // rounds against which the donation should be counted
+  }
+
+  // --- Events ---
   /// @notice Emitted when a new GrantRound contract is created
   event GrantRoundCreated(address grantRound);
 
   /// @notice Emitted when a donation has been made
-  event GrantDonation(
-    uint96 indexed grantId,
-    IERC20 indexed tokenIn,
-    uint256 amountIn,
-    uint256 amountOut,
-    GrantRound[] rounds
-  );
+  event GrantDonation(uint96 indexed grantId, IERC20 indexed tokenIn, uint256 donationAmount, GrantRound[] rounds);
 
+  // --- Constructor ---
   constructor(
     GrantRegistry _registry,
     ISwapRouter _router,
@@ -60,6 +71,8 @@ contract GrantRoundManager {
     router = _router;
     donationToken = _donationToken;
   }
+
+  // --- Core methods ---
 
   /**
    * @notice Creates a new GrantRound
@@ -99,66 +112,77 @@ contract GrantRoundManager {
   }
 
   /**
-   * @notice Swap and donate to a grant
-   * @param  _donation Donation being made to a grant
+   * @notice Performs swaps if necessary and donates funds as specified
+   * @param _swaps Array of SwapSummary objects describing the swaps required
+   * @param _deadline Unix timestamp after which a swap will revert, i.e. swap must be executed before this
+   * @param _donations Array of donations to execute
+   * @dev `_deadline` is not part of the `_swaps` array since all swaps can use the same `_deadline` to save some gas
+   * @dev Caller must ensure the input tokens to the _swaps array are unique
+   * @dev Does not verify
    */
-  function swapAndDonate(Donation calldata _donation) external payable {
+  function donate(
+    SwapSummary[] calldata _swaps,
+    uint256 _deadline,
+    Donation[] calldata _donations
+  ) external payable {
     // --- Validation ---
-    // Rounds must be specified
-    GrantRound[] calldata _rounds = _donation.rounds;
-    require(_rounds.length > 0, "GrantRoundManager: Must specify at least one round");
+    // TODO consider moving this to the section where we already loop through donations in case that saves a lot of
+    // gas. Leaving it here for now to improve readability
+    for (uint256 i = 0; i < _donations.length; i++) {
+      require(_donations[i].grantId < registry.grantCount(), "GrantRoundManager: Grant does not exist in registry");
 
-    // Only allow value to be sent if the input token is WETH (this limitation should be fixed in #76, as this
-    // require statement prohibits donating WETH)
-    IERC20 _tokenIn = IERC20(_donation.path.toAddress(0));
-    require(
-      (msg.value == 0 && address(_tokenIn) != WETH) || (msg.value > 0 && address(_tokenIn) == WETH),
-      "GrantRoundManager: Invalid token-value pairing"
-    );
-
-    // Ensure grant recieving donation exists in registry
-    uint96 _grantId = _donation.grantId;
-    require(_grantId < registry.grantCount(), "GrantRoundManager: Grant does not exist in registry");
-
-    // Iterate through each GrantRound to verify:
-    //   - The round has the same donationToken as the GrantRoundManager
-    //   - The round is active
-    for (uint256 i = 0; i < _rounds.length; i++) {
-      require(_rounds[i].isActive(), "GrantRoundManager: GrantRound is not active");
-      require(
-        donationToken == _rounds[i].donationToken(),
-        "GrantRoundManager: GrantRound's donation token does not match GrantRoundManager's donation token"
-      );
-    }
-
-    // --- Swap ---
-    address _payoutAddress = registry.getGrantPayee(_grantId);
-    uint256 _amountIn = _donation.amountIn;
-    uint256 _amountOut = _amountIn; // by default, by may be overwritten in the swap branch below
-
-    if (_tokenIn == donationToken && msg.value == 0) {
-      // ETH as the donation token is not supported, so ensure msg.value is zero
-      _tokenIn.safeTransferFrom(msg.sender, _payoutAddress, _amountOut); // transfer funds directly to payout address
-    } else {
-      // Swap setup
-      ISwapRouter.ExactInputParams memory params = ISwapRouter.ExactInputParams(
-        _donation.path,
-        _payoutAddress, // recipient
-        _donation.deadline,
-        _amountIn,
-        _donation.amountOutMinimum
-      );
-
-      // If user is sending a token, transfer it to this contract and approve the router to spend it
-      if (msg.value == 0) {
-        _tokenIn.safeTransferFrom(msg.sender, address(this), _amountIn);
-        _tokenIn.approve(address(router), type(uint256).max); // TODO optimize so we don't call this every time
+      GrantRound[] calldata _rounds = _donations[i].rounds;
+      require(_rounds.length > 0, "GrantRoundManager: Must specify at least one round");
+      for (uint256 j = 0; j < _rounds.length; j++) {
+        require(_rounds[j].isActive(), "GrantRoundManager: GrantRound is not active");
+        require(
+          donationToken == _rounds[j].donationToken(),
+          "GrantRoundManager: GrantRound's donation token does not match GrantRoundManager's donation token"
+        );
       }
-
-      // Execute swap -- output of swap is sent to the payoutAddress
-      _amountOut = router.exactInput{value: msg.value}(params);
     }
 
-    emit GrantDonation(_grantId, _tokenIn, _amountIn, _amountOut, _rounds);
+    // --- Execute all swaps ---
+    for (uint256 i = 0; i < _swaps.length; i++) {
+      // Do nothing if the swap input token equals donationToken
+      IERC20 _tokenIn = IERC20(_swaps[i].path.toAddress(0));
+      if (_tokenIn == donationToken) continue;
+
+      // Otherwise, execute swap
+      ISwapRouter.ExactInputParams memory params = ISwapRouter.ExactInputParams(
+        _swaps[i].path,
+        address(this), // send output to the contract and it will be transferred later
+        _deadline,
+        _swaps[i].amount,
+        _swaps[i].amountOutMinimum
+      );
+
+      require(swapOutputs[_tokenIn] == 0, "GrantRoundManager: Swap parameter has duplicate input tokens");
+      swapOutputs[_tokenIn] = router.exactInput{value: msg.value}(params); // save off output amount for later
+    }
+
+    // --- Execute donations ---
+    for (uint256 i = 0; i < _donations.length; i++) {
+      // Get data
+      GrantRound[] calldata _rounds = _donations[i].rounds;
+      uint96 _grantId = _donations[i].grantId;
+      IERC20 _tokenIn = _donations[i].token;
+      uint256 _donationAmount = (swapOutputs[_tokenIn] * _donations[i].ratio) / WAD;
+      address _payee = registry.getGrantPayee(_grantId);
+
+      // Execute transfer
+      if (_tokenIn == donationToken) {
+        _tokenIn.safeTransferFrom(msg.sender, _payee, _donationAmount); // transfer token directly from caller
+      } else {
+        donationToken.transfer(_payee, _donationAmount); // transfer swap output
+      }
+      emit GrantDonation(_grantId, _tokenIn, _donationAmount, _rounds);
+    }
+
+    // --- Clear storage ---
+    for (uint256 i = 0; i < _swaps.length; i++) {
+      IERC20 _tokenIn = IERC20(_swaps[i].path.toAddress(0));
+      swapOutputs[_tokenIn] = 0; // storage refund
+    }
   }
 }

--- a/contracts/contracts/GrantRoundManager.sol
+++ b/contracts/contracts/GrantRoundManager.sol
@@ -178,7 +178,8 @@ contract GrantRoundManager {
       );
 
       require(swapOutputs[_tokenIn] == 0, "GrantRoundManager: Swap parameter has duplicate input tokens");
-      swapOutputs[_tokenIn] = router.exactInput{value: msg.value}(params); // save off output amount for later
+      uint256 _value = _tokenIn == WETH && msg.value > 0 ? msg.value : 0;
+      swapOutputs[_tokenIn] = router.exactInput{value: _value}(params); // save off output amount for later
     }
 
     // --- Execute donations ---
@@ -188,6 +189,7 @@ contract GrantRoundManager {
       uint96 _grantId = _donations[i].grantId;
       IERC20 _tokenIn = _donations[i].token;
       uint256 _donationAmount = (swapOutputs[_tokenIn] * _donations[i].ratio) / WAD;
+      require(_donationAmount > 0, "GrantRoundManager: Donation amount must be greater than zero"); // verifies that swap and donation inputs are consistent
       address _payee = registry.getGrantPayee(_grantId);
 
       // Execute transfer

--- a/contracts/contracts/test/MockToken.sol
+++ b/contracts/contracts/test/MockToken.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.6;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
@@ -7,7 +8,7 @@ contract MockToken is ERC20 {
     _mint(msg.sender, initialSupply);
   }
 
-  function mint(uint256 initialSupply) external {
-    _mint(msg.sender, initialSupply);
+  function mint(uint256 amount) external {
+    _mint(msg.sender, amount);
   }
 }

--- a/contracts/test/GrantRoundManager.test.ts
+++ b/contracts/test/GrantRoundManager.test.ts
@@ -1,3 +1,9 @@
+/**
+ * @dev If you are writing tests and the test times out during a call to `donate`, this is likely because:
+ *     1. The Uniswap pool or path you are using does not exist on mainnet, or
+ *     2. There is not enough liquid on mainnet for the specified amountIn
+ */
+
 // --- External imports ---
 import { artifacts, ethers, waffle } from 'hardhat';
 import { Artifact } from 'hardhat/types';
@@ -5,10 +11,9 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 import { deployMockContract } from '@ethereum-waffle/mock-contract';
 import { MockContract } from 'ethereum-waffle';
 import { expect } from 'chai';
-// import { Pool, Route, encodeRouteToPath } from '@uniswap/v3-sdk'
 
 // --- Our imports ---
-import { ETH_ADDRESS, UNISWAP_ROUTER, tokens, approve, balanceOf, setBalance, encodeRoute } from './utils'; // prettier-ignore
+import { ETH_ADDRESS, UNISWAP_ROUTER, tokens, approve, balanceOf, setBalance, encodeRoute, getSwapAmountOut } from './utils'; // prettier-ignore
 import { GrantRoundManager } from '../typechain';
 import { SwapSummary, Donation } from '@dgrants/types';
 
@@ -16,6 +21,7 @@ import { SwapSummary, Donation } from '@dgrants/types';
 const { isAddress, parseUnits } = ethers.utils;
 const { deployContract } = waffle;
 const randomAddress = () => ethers.Wallet.createRandom().address;
+const WAD = parseUnits('1', 18);
 
 // --- GrantRoundManager tests ---
 describe('GrantRoundManager', () => {
@@ -30,7 +36,7 @@ describe('GrantRoundManager', () => {
     // Deploy mock contracts
     mockRegistry = await deployMockContract(user, artifacts.readArtifactSync('GrantRegistry').abi);
     mockToken = await deployMockContract(user, ['function totalSupply() returns(uint256)']);
-    await mockRegistry.mock.grantCount.returns('1');
+    await mockRegistry.mock.grantCount.returns('2');
     await mockToken.mock.totalSupply.returns('0');
 
     // Deploy Manager
@@ -93,6 +99,7 @@ describe('GrantRoundManager', () => {
     const endTime = '60000000000000'; // random timestamp far in the future
     const metaPtr = 'https://metadata-pointer.com';
     const minContribution = '100';
+
     beforeEach(async () => {
       // Deploy and configure mocks (used to pass the validation in the GrantRound constructor)
       mockRegistry = await deployMockContract(user, ['function grantCount() returns(uint96)']);
@@ -101,6 +108,7 @@ describe('GrantRoundManager', () => {
 
       mockMatchingToken = await deployMockContract(user, ['function totalSupply() returns(uint256)']);
     });
+
     it('creates new grant rounds', async () => {
       // Create a valid token supply
       await mockMatchingToken.mock.totalSupply.returns('100');
@@ -157,7 +165,7 @@ describe('GrantRoundManager', () => {
     let mockRound: MockContract;
     let swap: SwapSummary;
     let donation: Donation;
-    let payee: string; // address the grant owner receives donations to
+    let payee1: string, payee2: string; // addresses grant owners receive donations to
     const deadline = '10000000000'; // date of 2286-11-20 as swap deadline
 
     beforeEach(async () => {
@@ -167,22 +175,14 @@ describe('GrantRoundManager', () => {
       await mockRound.mock.isActive.returns(true);
 
       // Set payee address to be a random address
-      payee = randomAddress();
-      await mockRegistry.mock.getGrantPayee.returns(payee);
+      payee1 = randomAddress();
+      payee2 = randomAddress();
+      await mockRegistry.mock.getGrantPayee.withArgs('0').returns(payee1);
+      await mockRegistry.mock.getGrantPayee.withArgs('1').returns(payee2);
 
       // Configure default donation data
-      swap = {
-        amountIn: '1',
-        amountOutMin: '0',
-        path: await encodeRoute(['dai', 'eth', 'gtc']),
-      };
-
-      donation = {
-        grantId: 0,
-        token: tokens.dai.address,
-        ratio: parseUnits('1', 18),
-        rounds: [mockRound.address],
-      };
+      swap = { amountIn: '1', amountOutMin: '0', path: await encodeRoute(['dai', 'eth', 'gtc']) };
+      donation = { grantId: 0, token: tokens.dai.address, ratio: parseUnits('1', 18), rounds: [mockRound.address] };
 
       // Fund the first user with tokens
       await setBalance('dai', user.address, parseUnits('1000', 18));
@@ -190,82 +190,222 @@ describe('GrantRoundManager', () => {
       await setBalance('weth', user.address, parseUnits('1000', 18));
     });
 
-    it('reverts if no rounds are specified', async () => {
-      await expect(manager.donate([swap], deadline, [{ ...donation, rounds: [] }])).to.be.revertedWith(
-        'GrantRoundManager: Must specify at least one round'
-      );
+    describe('validations', () => {
+      it('reverts if no rounds are specified', async () => {
+        await expect(manager.donate([swap], deadline, [{ ...donation, rounds: [] }])).to.be.revertedWith(
+          'GrantRoundManager: Must specify at least one round'
+        );
+      });
+
+      it('reverts if an invalid grant ID is provided', async () => {
+        await expect(manager.donate([swap], deadline, [{ ...donation, grantId: '500' }])).to.be.revertedWith(
+          'GrantRoundManager: Grant does not exist in registry'
+        );
+      });
+
+      it('reverts if a provided grant round has a different donation token than the GrantRoundManager', async () => {
+        await mockRound.mock.donationToken.returns(ETH_ADDRESS);
+        await expect(manager.donate([swap], deadline, [{ ...donation }])).to.be.revertedWith(
+          "GrantRoundManager: GrantRound's donation token does not match GrantRoundManager's donation token"
+        );
+      });
+
+      it('reverts if a provided grant round is not active', async () => {
+        await mockRound.mock.isActive.returns(false);
+        await expect(manager.donate([swap], deadline, [{ ...donation }])).to.be.revertedWith(
+          'GrantRoundManager: GrantRound is not active'
+        );
+      });
+
+      it('reverts if swap and donate inputs are inconsistent, resulting in zero donation', async () => {
+        // No swap, just batch transfers
+        const swaps = [{ amountIn: parseUnits('100', 18), amountOutMin: '0', path: tokens.gtc.address }];
+        const donations = [
+          { grantId: 0, token: tokens.dai.address, ratio: parseUnits('0.25', 18), rounds: [mockRound.address] },
+          { grantId: 1, token: tokens.dai.address, ratio: parseUnits('0.75', 18), rounds: [mockRound.address] },
+        ];
+        expect(await balanceOf('gtc', payee1)).to.equal('0');
+        expect(await balanceOf('gtc', payee2)).to.equal('0');
+
+        await approve('gtc', user, manager.address);
+        await expect(manager.donate(swaps, deadline, donations)).to.be.revertedWith(
+          'GrantRoundManager: Donation amount must be greater than zero'
+        );
+      });
     });
 
-    it('reverts if an invalid grant ID is provided', async () => {
-      await expect(manager.donate([swap], deadline, [{ ...donation, grantId: '500' }])).to.be.revertedWith(
-        'GrantRoundManager: Grant does not exist in registry'
-      );
+    describe('one donation', () => {
+      it('input token GTC, output token GTC', async () => {
+        const amountIn = parseUnits('100', 18);
+        expect(await balanceOf('gtc', payee1)).to.equal('0');
+        await approve('gtc', user, manager.address);
+        await manager.donate([{ ...swap, path: tokens.gtc.address, amountIn }], deadline, [
+          { ...donation, token: tokens.gtc.address },
+        ]);
+        expect(await balanceOf('gtc', payee1)).to.equal(amountIn);
+      });
+
+      it('input token ETH, output token GTC', async () => {
+        // Use the 1% GTC/ETH pool to swap from ETH (input) to GTC (donationToken). The 1% pool is currently the most liquid
+        const amountIn = parseUnits('10', 18);
+        const tx = await manager.donate(
+          [{ ...swap, amountIn, path: await encodeRoute(['eth', 'gtc']) }],
+          deadline,
+          [{ ...donation, token: tokens.weth.address }],
+          { value: amountIn, gasPrice: '0' } // zero gas price to make balance checks simpler
+        );
+
+        // Get the donationAmount from the swap from the GrantDonation log
+        const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
+        const log = manager.interface.parseLog(receipt.logs[receipt.logs.length - 1]); // the event we want is the last one
+        const { donationAmount } = log.args;
+        expect(await balanceOf('gtc', payee1)).to.equal(donationAmount);
+      });
+
+      it('input token DAI, output token GTC, swap passes through ETH', async () => {
+        // Execute donation to the payee
+        const amountIn = parseUnits('100', 18);
+        await approve('dai', user, manager.address);
+        const tx = await manager.donate([{ ...swap, amountIn }], deadline, [donation]);
+
+        // Get the donationAmount from the swap from the GrantDonation log
+        const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
+        const log = manager.interface.parseLog(receipt.logs[receipt.logs.length - 1]); // the event we want is the last one
+        const { donationAmount } = log.args;
+        expect(await balanceOf('gtc', payee1)).to.equal(donationAmount);
+      });
+
+      it('emits a log on a successful donation', async () => {
+        // Execute donation to the payee using GTC as input
+        const amountIn = parseUnits('100', 18);
+        await approve('gtc', user, manager.address);
+        const tx = await manager.donate([{ ...swap, path: tokens.gtc.address, amountIn }], deadline, [
+          { ...donation, token: tokens.gtc.address },
+        ]);
+        await expect(tx)
+          .to.emit(manager, 'GrantDonation')
+          .withArgs('0', tokens.gtc.address, amountIn, [mockRound.address]);
+      });
     });
 
-    it('reverts if a provided grant round has a different donation token than the GrantRoundManager', async () => {
-      await mockRound.mock.donationToken.returns(ETH_ADDRESS);
-      await expect(manager.donate([swap], deadline, [{ ...donation }])).to.be.revertedWith(
-        "GrantRoundManager: GrantRound's donation token does not match GrantRoundManager's donation token"
-      );
-    });
+    describe('bulk donation, single token', () => {
+      it('input token GTC, output token GTC', async () => {
+        // No swap, just batch transfers
+        const swaps = [{ amountIn: parseUnits('100', 18), amountOutMin: '0', path: tokens.gtc.address }];
+        const donations = [
+          { grantId: 0, token: tokens.gtc.address, ratio: parseUnits('0.25', 18), rounds: [mockRound.address] },
+          { grantId: 1, token: tokens.gtc.address, ratio: parseUnits('0.75', 18), rounds: [mockRound.address] },
+        ];
 
-    it('reverts if a provided grant round is not active', async () => {
-      await mockRound.mock.isActive.returns(false);
-      await expect(manager.donate([swap], deadline, [{ ...donation }])).to.be.revertedWith(
-        'GrantRoundManager: GrantRound is not active'
-      );
-    });
+        await approve('gtc', user, manager.address);
+        await manager.donate(swaps, deadline, donations);
 
-    it('input token GTC, output token GTC', async () => {
-      const amountIn = parseUnits('100', 18);
-      expect(await balanceOf('gtc', payee)).to.equal('0');
-      await approve('gtc', user, manager.address);
-      await manager.donate([{ ...swap, path: tokens.gtc.address, amountIn }], deadline, [
-        { ...donation, token: tokens.gtc.address },
-      ]);
-      expect(await balanceOf('gtc', payee)).to.equal(amountIn);
-    });
+        const expectedBalancePayee1 = swaps[0].amountIn.mul(donations[0].ratio).div(WAD);
+        const expectedBalancePayee2 = swaps[0].amountIn.mul(donations[1].ratio).div(WAD);
+        expect(await balanceOf('gtc', payee1)).to.equal(expectedBalancePayee1);
+        expect(await balanceOf('gtc', payee2)).to.equal(expectedBalancePayee2);
+      });
 
-    it('input token ETH, output token GTC', async () => {
-      // Use the 1% GTC/ETH pool to swap from ETH (input) to GTC (donationToken). The 1% pool is currently the most liquid
-      const amountIn = parseUnits('10', 18);
-      const tx = await manager.donate(
-        [{ ...swap, amountIn, path: await encodeRoute(['eth', 'gtc']) }],
-        deadline,
-        [{ ...donation, token: tokens.weth.address }],
-        { value: amountIn, gasPrice: '0' } // zero gas price to make balance checks simpler
-      );
+      it('input token ETH, output token GTC', async () => {
+        const swaps = [{ amountIn: parseUnits('1', 18), amountOutMin: '0', path: await encodeRoute(['eth', 'gtc']) }];
+        const donations = [
+          { grantId: 0, token: tokens.weth.address, ratio: parseUnits('0.25', 18), rounds: [mockRound.address] },
+          { grantId: 1, token: tokens.weth.address, ratio: parseUnits('0.75', 18), rounds: [mockRound.address] },
+        ];
+        const tx = await manager.donate(swaps, deadline, donations, { value: swaps[0].amountIn, gasPrice: '0' });
 
-      // Get the donationAmount from the swap from the GrantDonation log
-      const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
-      const log = manager.interface.parseLog(receipt.logs[receipt.logs.length - 1]); // the event we want is the last one
-      const { donationAmount } = log.args;
-      expect(await balanceOf('gtc', payee)).to.equal(donationAmount);
-    });
+        const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
+        const amountOut = getSwapAmountOut(receipt.logs);
+        const expectedBalancePayee1 = amountOut.mul(donations[0].ratio).div(WAD);
+        const expectedBalancePayee2 = amountOut.mul(donations[1].ratio).div(WAD);
+        expect(await balanceOf('gtc', payee1)).to.equal(expectedBalancePayee1);
+        expect(await balanceOf('gtc', payee2)).to.equal(expectedBalancePayee2);
+      });
 
-    it('input token DAI, output token GTC, swap passes through ETH', async () => {
-      // Execute donation to the payee
-      const amountIn = parseUnits('100', 18);
-      await approve('dai', user, manager.address);
-      const tx = await manager.donate([{ ...swap, amountIn }], deadline, [donation]);
+      it('input token DAI, output token GTC, swap passes through ETH', async () => {
+        const path = await encodeRoute(['dai', 'eth', 'gtc']);
+        const swaps = [{ amountIn: parseUnits('1000', 18), amountOutMin: '0', path }];
+        const donations = [
+          { grantId: 0, token: tokens.dai.address, ratio: parseUnits('0.25', 18), rounds: [mockRound.address] },
+          { grantId: 1, token: tokens.dai.address, ratio: parseUnits('0.75', 18), rounds: [mockRound.address] },
+        ];
+        await approve('dai', user, manager.address);
+        const tx = await manager.donate(swaps, deadline, donations, { value: swaps[0].amountIn, gasPrice: '0' });
 
-      // Get the donationAmount from the swap from the GrantDonation log
-      const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
-      const log = manager.interface.parseLog(receipt.logs[receipt.logs.length - 1]); // the event we want is the last one
-      const { donationAmount } = log.args;
-      expect(await balanceOf('gtc', payee)).to.equal(donationAmount);
-    });
+        const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
+        const amountOut = getSwapAmountOut(receipt.logs);
+        const expectedBalancePayee1 = amountOut.mul(donations[0].ratio).div(WAD);
+        const expectedBalancePayee2 = amountOut.mul(donations[1].ratio).div(WAD);
+        expect(await balanceOf('gtc', payee1)).to.equal(expectedBalancePayee1);
+        expect(await balanceOf('gtc', payee2)).to.equal(expectedBalancePayee2);
+      });
 
-    it('emits a log on a successful donation', async () => {
-      // Execute donation to the payee using GTC as input
-      const amountIn = parseUnits('100', 18);
-      await approve('gtc', user, manager.address);
-      const tx = await manager.donate([{ ...swap, path: tokens.gtc.address, amountIn }], deadline, [
-        { ...donation, token: tokens.gtc.address },
-      ]);
-      await expect(tx)
-        .to.emit(manager, 'GrantDonation')
-        .withArgs('0', tokens.gtc.address, amountIn, [mockRound.address]);
+      it('input tokens DAI, ETH, GTC', async () => {
+        // Configure swaps and donations
+        const swaps = [
+          { amountIn: parseUnits('1000', 18), amountOutMin: '0', path: await encodeRoute(['dai', 'eth', 'gtc']) },
+          { amountIn: parseUnits('1', 18), amountOutMin: '0', path: await encodeRoute(['eth', 'gtc']) },
+          { amountIn: parseUnits('100', 18), amountOutMin: '0', path: tokens.gtc.address },
+        ];
+        const donations = [
+          { grantId: 0, token: tokens.dai.address, ratio: parseUnits('0.10', 18), rounds: [mockRound.address] },
+          { grantId: 1, token: tokens.dai.address, ratio: parseUnits('0.90', 18), rounds: [mockRound.address] },
+          { grantId: 2, token: tokens.weth.address, ratio: parseUnits('0.20', 18), rounds: [mockRound.address] },
+          { grantId: 3, token: tokens.weth.address, ratio: parseUnits('0.80', 18), rounds: [mockRound.address] },
+          { grantId: 4, token: tokens.gtc.address, ratio: parseUnits('0.30', 18), rounds: [mockRound.address] },
+          { grantId: 5, token: tokens.gtc.address, ratio: parseUnits('0.70', 18), rounds: [mockRound.address] },
+        ];
+
+        // Configure mocks
+        await mockRegistry.mock.grantCount.returns(donations.length); // ensure mock registry has enough grants
+        const payees = [...Array(donations.length)].map(() => randomAddress()); // array of random payee addresses
+        await Promise.all(
+          donations.map(async (donation) => {
+            await mockRegistry.mock.getGrantPayee.withArgs(donation.grantId).returns(payees[donation.grantId]);
+          })
+        );
+
+        // Execute donations
+        await approve('dai', user, manager.address);
+        await approve('gtc', user, manager.address);
+        const tx = await manager.donate(swaps, deadline, donations, { value: swaps[1].amountIn, gasPrice: '0' });
+
+        // Verify GTC outputs
+        expect(await balanceOf('gtc', payees[4])).to.equal(swaps[2].amountIn.mul(donations[4].ratio).div(WAD));
+        expect(await balanceOf('gtc', payees[5])).to.equal(swaps[2].amountIn.mul(donations[5].ratio).div(WAD));
+
+        // Verify ETH and DAI amounts, by parsing swap logs manually (i.e. hardcoding the appropriate indexes)
+        const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
+        const daiToGtcAmountOut = getSwapAmountOut([receipt.logs[6]]);
+        const ethToGtcAmountOut = getSwapAmountOut([receipt.logs[10]]);
+
+        expect(await balanceOf('gtc', payees[0])).to.equal(daiToGtcAmountOut.mul(donations[0].ratio).div(WAD));
+        expect(await balanceOf('gtc', payees[1])).to.equal(daiToGtcAmountOut.mul(donations[1].ratio).div(WAD));
+        expect(await balanceOf('gtc', payees[2])).to.equal(ethToGtcAmountOut.mul(donations[2].ratio).div(WAD));
+        expect(await balanceOf('gtc', payees[3])).to.equal(ethToGtcAmountOut.mul(donations[3].ratio).div(WAD));
+      });
+
+      it('emits a log for each successful donation', async () => {
+        const swaps = [{ amountIn: parseUnits('1', 18), amountOutMin: '0', path: await encodeRoute(['eth', 'gtc']) }];
+        const donations = [
+          { grantId: 0, token: tokens.weth.address, ratio: parseUnits('0.25', 18), rounds: [mockRound.address] },
+          { grantId: 1, token: tokens.weth.address, ratio: parseUnits('0.75', 18), rounds: [mockRound.address] },
+        ];
+        const tx = await manager.donate(swaps, deadline, donations, { value: swaps[0].amountIn, gasPrice: '0' });
+
+        // Chai event matcher uses last log when there's multiple logs of the same name
+        const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
+        const amountOut = getSwapAmountOut(receipt.logs);
+        const expectedBalancePayee2 = amountOut.mul(donations[1].ratio).div(WAD);
+        await expect(tx)
+          .to.emit(manager, 'GrantDonation')
+          .withArgs('1', tokens.weth.address, expectedBalancePayee2, [mockRound.address]);
+
+        // Also verify number of GrantDonation events
+        const grantDonationTopic = manager.interface.getEventTopic('GrantDonation');
+        const grantDonationLogs = receipt.logs.filter((log) => log.topics[0] === grantDonationTopic);
+        expect(grantDonationLogs.length).to.equal(donations.length);
+      });
     });
   });
 });

--- a/types/src/grants.d.ts
+++ b/types/src/grants.d.ts
@@ -1,4 +1,4 @@
-import { BigNumber, BigNumberish } from 'ethers';
+import { BigNumber, BigNumberish, BytesLike } from 'ethers';
 import { TokenInfo } from '@uniswap/token-lists';
 
 // --- Types ---
@@ -14,15 +14,21 @@ export type GrantArray = [BigNumber, string, string, string];
 export type GrantEthers = GrantArray & GrantObject;
 export type Grant = GrantObject | GrantEthers;
 
-// Donation object from GrantRoundManager
+// SwapSummary struct from GrantRoundManager
+export interface SwapSummary {
+  amountIn: BigNumberish;
+  amountOutMin: BigNumberish;
+  path: BytesLike; // encoded swap path
+}
+
+// Donation struct from GrantRoundManager
 export interface Donation {
   grantId: BigNumberish;
+  token: string; // token address
+  ratio: BigNumberish;
   rounds: string[];
-  path: string;
-  deadline: BigNumberish;
-  amountIn: BigNumberish;
-  amountOutMinimum: BigNumberish;
 }
+
 // GrantRound object from GrantRoundManager
 export type GrantRound = {
   address: string;
@@ -38,6 +44,6 @@ export type GrantRound = {
   metaPtr: string;
   minContribution: BigNumberish;
   hasPaidOut: boolean;
-  error: string|undefined;
+  error: string | undefined;
 };
 export type GrantRounds = Array<GrantRound>;


### PR DESCRIPTION
Closes #76

The `GrantRoundManager` contract, and in particular the `donate` method, feel a bit clunky now, but I'm not totally sure how to clean it up. There's a few things that we could handle in separate issues to make it cleaner, so curious to hear thoughts around this:
- Making the `payee` address the grant ID (#54) removes a validation check
- Add an `assertValidContribution(address token)` method to the `GrantRound` can be used to combine the `isActive` and `donationToken` checks into a single call
- Making the `GrantRoundManager` inherit from `SwapRouter` (#74) would remove approvals and transfers that are currently needed
- Other ideas?

Current code coverage results are below

![image](https://user-images.githubusercontent.com/17163988/129048277-ba74d173-9145-4f5d-8822-ceca9bb1e7ef.png)
