### PR TITLE
Adding info about github discussions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,10 +8,13 @@ Reading and following these guidelines will help us make the contribution proces
 
 * [Code of Conduct](#code-of-conduct)
 * [Getting Started](#getting-started)
+    * [Ideas](#ideas)
     * [Discussions](#discussions)
     * [Issues](#issues)
     * [Pull Requests](#pull-requests)
       * [Git Rebase Workflow](#git-rebase-workflow)
+    * [Show and Tell](#show-and-tell)
+    * [Development Process](#development-process)
 * [Getting Help](#getting-help)
 
 ## Code of Conduct
@@ -30,18 +33,29 @@ faith and everyone is working towards a common goal.
 
 ## Getting Started
 
-Contributions are made to this repo via Discussions, Issues and Pull Requests (PRs). A few general guidelines that cover the trio:
+Contributions are made to this repo via Ideas, Discussions, Issues and Pull Requests (PRs).
 
+[Discussions > Ideas](https://github.com/dcgtc/dgrants/discussions/categories/ideas) - Propose and discuss ideas for new features or changes not currently in the dGrants design/architecture
+[Discussions > Architecture & Design](https://github.com/dcgtc/dgrants/discussions/categories/architecture-design) - Propose and discuss architecture and design for features or components in the current design that do not have clear or detailed definition
+[Issues](https://github.com/dcgtc/dgrants/issues) - Report problems with dGrants or add work to be done on a feature that is within the scope of the current design/architecture
+
+
+A few general guidelines that cover these:
 - Search for existing Descriptions, Issues and PRs before creating your own.
 - We work hard to makes sure issues are handled in a timely manner but, depending on the impact, it could take a while to investigate the root cause. A friendly ping in the comment thread to the submitter or a contributor can help draw attention if your issue is blocking.
 
-### Discussions
+**Additional Discussion Areas**
+[Discussions > Dev Meta](https://github.com/dcgtc/dgrants/discussions/categories/dev-meta) - Discuss development process, CI/CD, and similar topics here
+[Discussions > Show and Tell](https://github.com/dcgtc/dgrants/discussions/categories/show-and-tell) - Share something that you've built on top of or using the dGrants platform
 
+### Discussions > Ideas
+Submit an Idea when requesting a new feature, or update an existing feature that is not currently identified in the dGrants architecture or scope.
+
+### Discussions > Architecture & Design
 Discussion should be used to discuss potential changes before an issue or PR is created, or discussing the implementation on a current feature. Once the discussion has ended with participation from the community and maintainers, if changes need to made to the codebase, follow it up by creating an issue.
 
 ### Issues
-
-Issues should be used to report problems with the dApp, request a new feature, or update an existing feature (and features should have a discussion on the discussion board before creating an issue). When you create a new Issue, a template will be loaded that will guide you through collecting and providing the information we need to investigate.
+Issues should be used to report problems with the dApp, or capture work to be done for features within the scope of the current architecture that are well defined. When you create a new Issue, a template will be loaded that will guide you through collecting and providing the information we need to investigate.
 
 If you find an Issue that addresses the problem you're having, please add your own reproduction information to the existing issue rather than creating a new one. Adding a [reaction](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) can also help be indicating to our maintainers that a particular problem is affecting more than just the reporter.
 
@@ -101,7 +115,7 @@ git push origin my-feature-branch --force
 ```
 
 Every PR merged should merged with GitHub's "Rebase and Merge" button, or with a fast-forward merge on the command line, like:
- 
+
 ```bash
 git checkout main
 git merge my-feature-branch --ff-only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,12 +8,14 @@ Reading and following these guidelines will help us make the contribution proces
 
 * [Code of Conduct](#code-of-conduct)
 * [Getting Started](#getting-started)
-    * [Ideas](#ideas)
     * [Discussions](#discussions)
+      * [Ideas](#ideas)
+      * [Architecture & Design](#architecture-&-design)
+      * [Dev Meta](#dev-meta)
+      * [Show and Tell](#show-and-tell)
     * [Issues](#issues)
     * [Pull Requests](#pull-requests)
       * [Git Rebase Workflow](#git-rebase-workflow)
-    * [Show and Tell](#show-and-tell)
     * [Development Process](#development-process)
 * [Getting Help](#getting-help)
 
@@ -35,31 +37,55 @@ faith and everyone is working towards a common goal.
 
 Contributions are made to this repo via Ideas, Discussions, Issues and Pull Requests (PRs).
 
-[Discussions > Ideas](https://github.com/dcgtc/dgrants/discussions/categories/ideas) - Propose and discuss ideas for new features or changes not currently in the dGrants design/architecture
-[Discussions > Architecture & Design](https://github.com/dcgtc/dgrants/discussions/categories/architecture-design) - Propose and discuss architecture and design for features or components in the current design that do not have clear or detailed definition
-[Issues](https://github.com/dcgtc/dgrants/issues) - Report problems with dGrants or add work to be done on a feature that is within the scope of the current design/architecture
+- [Discussions > Ideas](https://github.com/dcgtc/dgrants/discussions/categories/ideas) - Propose and discuss ideas for new features or changes not currently in the dGrants design/architecture
+- [Discussions > Architecture & Design](https://github.com/dcgtc/dgrants/discussions/categories/architecture-design) - Propose and discuss architecture and design for features or components in the current design that do not have clear or detailed definition
+- [Issues](https://github.com/dcgtc/dgrants/issues) - Report problems with dGrants or add work to be done on a feature that is within the scope of the current design/architecture
 
+**Other Discussion Channels**
+
+- [Discussions > Dev Meta](https://github.com/dcgtc/dgrants/discussions/categories/dev-meta) - Discuss development process, CI/CD, and similar topics here
+- [Discussions > Show and Tell](https://github.com/dcgtc/dgrants/discussions/categories/show-and-tell) - Share something that you've built on top of or using the dGrants platform
 
 A few general guidelines that cover these:
-- Search for existing Descriptions, Issues and PRs before creating your own.
+
+- Search for existing Discussions, Issues and PRs before creating your own.
 - We work hard to makes sure issues are handled in a timely manner but, depending on the impact, it could take a while to investigate the root cause. A friendly ping in the comment thread to the submitter or a contributor can help draw attention if your issue is blocking.
 
-**Additional Discussion Areas**
-[Discussions > Dev Meta](https://github.com/dcgtc/dgrants/discussions/categories/dev-meta) - Discuss development process, CI/CD, and similar topics here
-[Discussions > Show and Tell](https://github.com/dcgtc/dgrants/discussions/categories/show-and-tell) - Share something that you've built on top of or using the dGrants platform
 
-### Discussions > Ideas
+### Discussions
+
+#### Ideas
 Submit an Idea when requesting a new feature, or update an existing feature that is not currently identified in the dGrants architecture or scope.
 
-### Discussions > Architecture & Design
+View: [Ideas](https://github.com/dcgtc/dgrants/discussions/categories/ideas)
+
+#### Architecture & Design
+
 Discussion should be used to discuss potential changes before an issue or PR is created, or discussing the implementation on a current feature. Once the discussion has ended with participation from the community and maintainers, if changes need to made to the codebase, follow it up by creating an issue.
 
+View: [Architecture & Design Discussions.](https://github.com/dcgtc/dgrants/discussions/categories/architecture-design)
+
+### Dev Meta
+
+Discussions related to development process, CI/CD, and similar topics here. (AKA which affect the how we work)
+
+View: [Dev meta](https://github.com/dcgtc/dgrants/discussions/categories/dev-meta)
+
+### Show and Tell
+
+Meant to showcase applications which have been built on top of the dGrants platform
+
+View: [Show and Tell](https://github.com/dcgtc/dgrants/discussions/categories/dev-meta)
+
 ### Issues
+
 Issues should be used to report problems with the dApp, or capture work to be done for features within the scope of the current architecture that are well defined. When you create a new Issue, a template will be loaded that will guide you through collecting and providing the information we need to investigate.
 
 If you find an Issue that addresses the problem you're having, please add your own reproduction information to the existing issue rather than creating a new one. Adding a [reaction](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) can also help be indicating to our maintainers that a particular problem is affecting more than just the reporter.
 
 When creating a new issue, please do your best to be as detailed and specific as possible.
+
+View: [Issues](https://github.com/dcgtc/dgrants/issues)
 
 ### Pull Requests
 


### PR DESCRIPTION
Trimmed down the categories on github discussions and captured that in the contributing doc here.