### PR TITLE
fix: Fixes missing match value for when the filter fails

### DIFF
--- a/dcurve/src/internal/utils.ts
+++ b/dcurve/src/internal/utils.ts
@@ -45,5 +45,5 @@ export const getGrantMatch = (grantId: string, grantsDistribution: GrantsDistrib
     (grantMatch) => grantMatch.grantId === grantId
   );
 
-  return contributions[0].match;
+  return contributions[0]?.match || 0;
 };


### PR DESCRIPTION
To discover each prediction point we filter the distribution to find the match for the grant - there are situations where the filter will not find a result and instead we should default to a match of 0.

--

Fixes: #168