### PR TITLE
build: fix errors when running 'yarn build'

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -21,7 +21,4 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['electron'],
   },
-  define: {
-    'process.env': process.env,
-  },
 });

--- a/tsconfig.settings.json
+++ b/tsconfig.settings.json
@@ -8,6 +8,8 @@
       "noUnusedLocals": true,
       "noUnusedParameters": true,
       "noImplicitReturns": true,
-      "declaration": true
+      "declaration": true,
+      "resolveJsonModule": true,
+      "esModuleInterop": true
     }
   }


### PR DESCRIPTION
`resolveJsonModule: true` was needed to resolve:

``` 
@dgrants/types: ../node_modules/@uniswap/token-lists/dist/index.d.ts(1,20): error TS2732: Cannot find module './tokenlist.schema.json'. Consider using '--resolveJsonModule' to import module with '.json' extension.
```

After that was added, `esModuleInterop: true` (sorry @wildmolasses I think you advise not using this 😬 ) was needed to resolve:

```
@dgrants/types: ../node_modules/@uniswap/token-lists/dist/index.d.ts(1,8): error TS1259: Module '"/Users/mds/Documents/projects/gitcoin/dgrants/node_modules/@uniswap/token-lists/dist/tokenlist.schema"' can only be default-imported using the 'esModuleInterop' flag
@dgrants/types: ../node_modules/@uniswap/token-lists/dist/index.d.ts(1,8): error TS1259: Module '"/Users/mds/Documents/projects/gitcoin/dgrants/node_modules/@uniswap/token-lists/dist/tokenlist.schema"' can only be default-imported using the 'esModuleInterop' flag
```

And finally, after that, removing the `process.env` declaration, since it seems to conflict with the `process: 'process/browser'` alias in the Vite config, was needed to resolve:

```
@dgrants/app: [commonjs] Unexpected token (157:42) in /Users/mds/Documents/projects/gitcoin/dgrants/node_modules/process/browser.js
@dgrants/app: file: /Users/mds/Documents/projects/gitcoin/dgrants/node_modules/process/browser.js:157:42
@dgrants/app: 155: process.title = 'browser';
@dgrants/app: 156: process.browser = true;
@dgrants/app: 157: process.env = {};
@dgrants/app:                       ^
@dgrants/app: 158: process.argv = [];
@dgrants/app: 159: process.version = ''; // empty string to avoid regexp issues
@dgrants/app: error during build:
@dgrants/app: SyntaxError: Unexpected token (157:42) in /Users/mds/Documents/projects/gitcoin/dgrants/node_modules/process/browser.js
```

`yarn build` and `yarn dev` both work, but I have not fully tested the app functionality, which must be done before merging