### PR TITLE
feat: add GrantRoundPage + add metadata

### DIFF
--- a/app/src/router/index.ts
+++ b/app/src/router/index.ts
@@ -18,6 +18,11 @@ const routes: Array<RouteRecordRaw> = [
   { path: '/dgrants/rounds/', name: 'dgrants-rounds-list', component: () => import('../views/GrantRoundsList.vue') },
   {
     path: '/dgrants/rounds/:address',
+    name: 'dgrants-round',
+    component: () => import('../views/GrantRound.vue'),
+  },
+  {
+    path: '/dgrants/rounds/:address/grants',
     name: 'dgrants-round-details',
     component: () => import('../views/GrantRoundDetails.vue'),
   },

--- a/app/src/views/GrantRound.vue
+++ b/app/src/views/GrantRound.vue
@@ -1,0 +1,305 @@
+<template>
+  <!-- GrantRound details -->
+  <div v-if="!isContributing">
+    <div v-if="grantRound.address">
+      <h1 class="my-6 text-center text-3xl font-extrabold text-gray-900">
+        Details for Grant Round: <span :title="grantRound.address">{{ formatAddress(grantRound.address) }}</span>
+      </h1>
+      <p>Name: {{ grantRoundMetadata?.name }}</p>
+      <p>Description: {{ grantRoundMetadata?.description }}</p>
+      <p>Status: {{ grantRound.status }}</p>
+      <p>Matching: {{ grantRoundMetadata?.matchingAlgorithm }}</p>
+      <p>Website: {{ grantRoundMetadata?.properties?.websiteURI }}</p>
+      <p>Governance: {{ grantRoundMetadata?.properties?.governanceURI }}</p>
+      <p>Twitter: {{ grantRoundMetadata?.properties?.twitterURI }}</p>
+      <p>sponsors: {{ grantRoundMetadata?.properties?.sponsorsURI }}</p>
+      <p>Img: {{ grantRoundMetadata?.logoURI }}</p>
+
+      <p>
+        Funds:
+        <a
+          class="link"
+          :title="grantRound.matchingToken.name"
+          :href="`https://etherscan.io/token/${grantRound.matchingToken.address}?a=${grantRound.address}`"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {{ grantRound.funds.toString() }} {{ grantRound.matchingToken.symbol }}
+        </a>
+      </p>
+      <p>
+        {{ hasStatus('Upcoming')(grantRound) ? 'Will begin' : 'Started' }}:
+        <span :title="new Date(BigNumber.from(grantRound.startTime).toNumber() * 1000).toLocaleString()">
+          {{ daysAgo(BigNumber.from(grantRound.startTime).toNumber()) }}
+        </span>
+      </p>
+      <p>
+        {{ hasStatus('Completed')(grantRound) ? 'Ended' : 'Will end' }}:
+        <span :title="new Date(BigNumber.from(grantRound.endTime).toNumber() * 1000).toLocaleString()">
+          {{ daysAgo(BigNumber.from(grantRound.endTime).toNumber()) }}
+        </span>
+      </p>
+      <p v-if="hasStatus('Completed')(grantRound)">
+        Has paid out:
+        <span>{{ grantRound.hasPaidOut ? 'Yes' : 'No' }}</span>
+      </p>
+      <p>
+        Metadata Admin:
+        <a
+          class="link"
+          :href="`https://etherscan.io/address/${grantRound.metadataAdmin}`"
+          target="_blank"
+          rel="noopener noreferrer"
+          >{{ grantRound.metadataAdmin }}</a
+        >
+      </p>
+      <p>
+        Payout Admin:
+        <a
+          class="link"
+          :href="`https://etherscan.io/address/${grantRound.payoutAdmin}`"
+          target="_blank"
+          rel="noopener noreferrer"
+          >{{ grantRound.payoutAdmin }}</a
+        >
+      </p>
+      <p>
+        Address:
+        <a
+          class="link"
+          :href="`https://etherscan.io/address/${grantRound.address}`"
+          target="_blank"
+          rel="noopener noreferrer"
+          >{{ grantRound.address }}</a
+        >
+      </p>
+      <div class="flex justify-center">
+        <button
+          @click="pushRoute({ name: 'dgrants-round-details', params: { address: grantRound.address } })"
+          class="btn btn-primary mt-6"
+        >
+          See Grants
+        </button>
+        <button @click="startContributing" class="btn btn-primary mt-6">Contribute to the matching fund</button>
+      </div>
+    </div>
+    <div v-else-if="grantRound.error">
+      <span>{{ grantRound.error }}</span>
+    </div>
+    <div v-else>
+      <span>Loading details...</span>
+    </div>
+  </div>
+
+  <!-- Contributing to GrantRound -->
+  <div v-else class="flex flex-col justify-center sm:px-6 lg:px-8">
+    <div class="sm:mx-auto sm:w-full sm:max-w-md">
+      <img
+        class="mx-auto h-12 w-auto"
+        src="https://tailwindui.com/img/logos/workflow-mark-indigo-600.svg"
+        alt="Workflow"
+      />
+      <h2 class="mt-6 text-center text-3xl font-extrabold text-gray-900">
+        Contribute to GrantRound {{ formatAddress(grantRound.address.toString()) }}
+      </h2>
+    </div>
+
+    <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md text-left">
+      <div class="py-8 px-4 border border-gray-200 shadow sm:rounded-lg sm:px-6 bg-gray-50">
+        <form class="space-y-6" @submit.prevent="sendContribution">
+          <!-- token address -->
+          <BaseInput
+            v-model="form.token"
+            description="The token used to make the contribution"
+            id="contribution-token-address"
+            label="Contribution Token address"
+            :readonly="true"
+            :disabled="true"
+            :rules="isValidAddress"
+            errorMsg="Please enter a valid address"
+          />
+
+          <!-- contribution amount -->
+          <BaseInput
+            v-model="form.amount"
+            description="The number of tokens to contribute"
+            id="contribution-amount"
+            label="Contribution amount"
+            :rules="isAmountValid"
+            errorMsg="Please enter an amount greater than 0"
+          />
+
+          <!-- Submit and cancel buttons -->
+          <button
+            type="submit"
+            class="btn btn-primary w-full"
+            :class="{ disabled: !isFormValid }"
+            :disabled="!isFormValid"
+          >
+            Send Contribution
+          </button>
+          <button @click.prevent="cancelContribution" class="btn btn-outline w-full">Cancel</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, ref } from 'vue';
+import { useRoute } from 'vue-router';
+
+// --- App Imports ---
+import BaseInput from 'src/components/BaseInput.vue';
+
+// --- Store ---
+import useDataStore from 'src/store/data';
+import useWalletStore from 'src/store/wallet';
+// --- Methods and Data ---
+import { GRANT_ROUND_ABI, ERC20_ABI } from 'src/utils/constants';
+import {
+  BigNumber,
+  BigNumberish,
+  Contract,
+  ContractTransaction,
+  getAddress,
+  MaxUint256,
+  parseUnits,
+} from 'src/utils/ethers';
+import {
+  daysAgo,
+  formatAddress,
+  isValidAddress,
+  isValidUrl,
+  checkAllowance,
+  getApproval,
+  hasStatus,
+  pushRoute,
+} from 'src/utils/utils';
+// --- Types ---
+import { GrantRound } from '@dgrants/types';
+import { GrantRound as GrantRoundContract } from '@dgrants/contracts';
+
+function useGrantRoundDetail() {
+  const { grantRounds, grantRoundMetadata: _grantRoundMetadata, poll } = useDataStore();
+
+  const { signer, userAddress } = useWalletStore();
+  const route = useRoute();
+
+  // get a single grantRound or an empty/error object (TODO: should the typings be modified to account for an empty object?)
+  const grantRound = computed(() => {
+    if (grantRounds.value) {
+      // filter for a matching GrantRound
+      const round = grantRounds.value.filter((round) => round.address === getAddress(<string>route.params.address));
+
+      return <GrantRound>(round.length ? round[0] : { error: `No GrantRound @ ${route.params.address}` });
+    } else {
+      return <GrantRound>{};
+    }
+  });
+
+  const grantRoundMetadata = computed(() =>
+    grantRound.value ? _grantRoundMetadata.value[grantRound.value.metaPtr] : null
+  );
+
+  // --- Contribution capabilities ---
+  const isContributing = ref(false);
+  const form = computed<{ token: string; amount: string }>(() => {
+    return {
+      token: grantRound.value.matchingToken.address,
+      amount: String(grantRound.value.minContribution),
+    };
+  });
+  const isAmountValid = (amount: BigNumberish) => {
+    return (Number(amount) || 0) > 0;
+  };
+  const isFormValid = computed(() => {
+    const { token, amount } = form.value;
+    const areFieldsValid =
+      isValidAddress(<string>token) && token === grantRound.value.matchingToken.address && isAmountValid(amount);
+    return areFieldsValid;
+  });
+
+  /**
+   * @notice Show the contribution window
+   */
+  function startContributing() {
+    isContributing.value = true; // show contribution form
+  }
+
+  /**
+   * @notice Hide the contribution window
+   */
+  function cancelContribution() {
+    isContributing.value = false; // hide contribution form
+  }
+
+  /**
+   * @notice Send contribution
+   */
+  async function sendContribution() {
+    // Get contract instances
+    if (!signer.value) throw new Error('Please connect a wallet');
+
+    // pull data from form
+    const { amount } = form.value;
+
+    // set up contracts
+    const token = new Contract(grantRound.value.matchingToken.address, ERC20_ABI, signer.value);
+    const round = <GrantRoundContract>new Contract(grantRound.value.address, GRANT_ROUND_ABI, signer.value);
+
+    // contributionAmount must have the right number of decimals and be hexed
+    const contributionAmount = parseUnits(amount, grantRound.value.matchingToken.decimals);
+
+    // check if contract is already approved as a spender
+    const allowance = await checkAllowance(token, userAddress.value, grantRound.value.address);
+    if (allowance < contributionAmount) {
+      await getApproval(token, grantRound.value.address, MaxUint256);
+    }
+
+    // invoke addMatchingFunds on the round contract
+    await addMatchingFunds(round, contributionAmount);
+
+    // poll for the updated state and toggle page state back to display mode
+    await poll();
+    cancelContribution();
+  }
+
+  /**
+   * @notice Submit `addMatchingFunds` tx to contribute to the fund
+   */
+  async function addMatchingFunds(round: GrantRoundContract, amount: BigNumber) {
+    // send funds to the matching pool (*Note: Unable to test this until we get an ERC20 balance into the hardhat accounts)
+    const tx: ContractTransaction = await round.addMatchingFunds(amount);
+    // After tx mines, poll so the store has the latest data
+    await tx.wait();
+  }
+
+  return {
+    BigNumber,
+    hasStatus,
+    daysAgo,
+    formatAddress,
+    isAmountValid,
+    isContributing,
+    isValidAddress,
+    isValidUrl,
+    isFormValid,
+    grantRound,
+    grantRoundMetadata,
+    form,
+    startContributing,
+    cancelContribution,
+    sendContribution,
+    pushRoute,
+  };
+}
+
+export default defineComponent({
+  name: 'GrantRoundDetails',
+  components: { BaseInput },
+  setup() {
+    return { ...useGrantRoundDetail() };
+  },
+});
+</script>

--- a/app/src/views/GrantRoundsList.vue
+++ b/app/src/views/GrantRoundsList.vue
@@ -10,7 +10,7 @@
         <li
           v-for="(grantRound, index) in list.rounds"
           :key="index"
-          @click="pushRoute({ name: 'dgrants-round-details', params: { address: grantRound.address } })"
+          @click="pushRoute({ name: 'dgrants-round', params: { address: grantRound.address } })"
           class="
             col-span-1
             bg-white

--- a/contracts/scripts/app.ts
+++ b/contracts/scripts/app.ts
@@ -67,7 +67,7 @@ const fixtureRound = async (registry: Contract, manager: Contract) => {
   const metadataAdmin = '0x34f4E532a33EB545941e914B25Efe348Aea31f0A';
   const payoutAdmin = '0x06c94663E5884BE4cCe85F0869e95C7712d34803';
   const matchingToken = tokens.dai.address;
-  const metaPtr = 'https://ipfs-dev.fleek.co/ipfs/bafybeighltnmw24tlbyulaiim3qh4lhjz3mfylilvsmr7atyyke2bfv7pe';
+  const metaPtr = 'https://ipfs-dev.fleek.co/ipfs/bafybeiejov726khhgtcr4hzjzohoo5x4xzxp7c3nng55z4iv4xj6fpan2a';
   const minContribution = ethers.constants.One;
 
   const tx = await manager.createGrantRound(

--- a/types/src/grantRounds.d.ts
+++ b/types/src/grantRounds.d.ts
@@ -25,6 +25,14 @@ export type GrantRoundMetadata = {
   name: string;
   description: string;
   grants: BigNumberish[];
+  matchingAlgorithm: string;
+  logoURI: string;
+  properties?: {
+    websiteURI?: string;
+    governanceURI?: string;
+    twitterURI?: string;
+    sponsorsURI?: string[];
+  };
 };
 export type GrantRoundMetadataStatus = 'resolved' | 'pending' | 'error';
 export type GrantRoundMetadataResolution = Partial<GrantRoundMetadata> & { status: GrantRoundMetadataStatus };


### PR DESCRIPTION
### Description

- introduced new view GrantRound  which shows details of a given round
- tweak IPFS GrantRound metaPtr to include new data elements
- display new elements on GrantRound Page
- update routes so that 
  - `dgrants/rounds/:address`  shows Grant round Info 
  - `dgrants/rounds/:address/grants` shows the actual Grants in the GrantRound
  
  
### Pending

- Tweaking the UI based on design (this could be in a standalone PR)


Here is the metaPtr structure: http://storageapi.fleek.co/thelostone-mc-team-bucket/round.json
