### PR TITLE
improved ui for cart

### DIFF
--- a/app/src/assets/placeholder_grant.svg
+++ b/app/src/assets/placeholder_grant.svg
@@ -1,0 +1,9 @@
+<svg width="1920" height="1080" viewBox="0 0 1920 1080" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="1920" height="1080" fill="white"/>
+<path d="M984.188 635.875H935.813" stroke="#E2E0E7" stroke-width="6" stroke-miterlimit="10"/>
+<path d="M988.438 535.875L1014.87 583" stroke="#E2E0E7" stroke-width="6" stroke-miterlimit="10"/>
+<path d="M905.125 583L931.563 535.875" stroke="#E2E0E7" stroke-width="6" stroke-miterlimit="10"/>
+<path d="M1022.88 516L960 552.313L897.125 516L960 407L1022.88 516Z" stroke="#E2E0E7" stroke-width="6" stroke-miterlimit="10"/>
+<path d="M1110 673.375H984.188V600.75L1047.13 564.375L1110 673.375Z" stroke="#E2E0E7" stroke-width="6" stroke-miterlimit="10"/>
+<path d="M935.813 600.75V673.375H810L872.875 564.375L935.813 600.75Z" stroke="#E2E0E7" stroke-width="6" stroke-miterlimit="10"/>
+</svg>

--- a/app/src/components/BaseInput.vue
+++ b/app/src/components/BaseInput.vue
@@ -1,37 +1,12 @@
 <template>
-  <div
-    :class="[
-      'grid',
-      'grid-cols-12',
-      'items-center',
-      'gap-m-8',
-      'border-grey-100',
-      showBorder ? 'py-5 border-b' : 'py-1',
-    ]"
-  >
-    <div class="col-span-12 md:col-span-3 mb-3 md:mb-0 grid-rows-3">
-      <label :for="id" class="text-grey-400"> {{ label }} <span v-if="!required" class="">(optional)</span>: </label>
-    </div>
-
-    <div class="col-span-10 md:col-span-6">
+  <div :class="width">
+    <label :for="id" class="block text-sm font-medium text-gray-700"> {{ label }} </label>
+    <p :for="id" class="text-gray-500 text-sm">{{ description }}</p>
+    <div>
       <input
         v-model="val"
         @input="onInput"
-        :class="[
-          'hy',
-          'appearance-none',
-          'bg-white',
-          'block',
-          'px-3',
-          'py-4',
-          'border border-grey-400',
-          'shadow-sm',
-          'placeholder-grey-400',
-          'focus:outline-none focus:ring-primary-500 focus:border-primary-500',
-          'sm:text-sm',
-          width,
-          !isValid ? 'border-red-300 text-red-900 placeholder-red-300 focus:ring-red-500 focus:border-red-500' : '',
-        ]"
+        :class="[!isValid ? 'border-pink text-pink' : '', customcss ? customcss : '']"
         :id="id"
         :name="id"
         :required="required"
@@ -70,7 +45,8 @@ export default defineComponent({
     readonly: { type: Boolean, required: false, default: false }, // is readonly
     disabled: { type: Boolean, required: false, default: false }, // is disabled
     width: { type: String, required: false, default: 'w-full' }, // input field width
-    showBorder: { type: Boolean, requred: false, default: true }, // show border below input
+    customcss: { type: String, required: false, default: '' }, // add custom css stylings
+
     rules: {
       // Validation rules, as a function that takes one input and returns a bool
       type: Function,

--- a/app/src/components/BaseSelect.vue
+++ b/app/src/components/BaseSelect.vue
@@ -1,23 +1,22 @@
 <template>
-  <Listbox as="div" :modelValue="modelValue" @update:model-value="$emit('update:modelValue', $event)">
-    <div class="mt-1 relative">
-      <ListboxButton
-        class="
-          bg-white
-          relative
-          w-28
-          border border-grey-400
-          shadow-sm
-          pl-3
-          pr-10
-          py-4
-          text-left
-          cursor-default
-          focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500
-          sm:text-sm
-        "
-      >
-        <span class="block truncate">{{ modelValue[label] }}</span>
+  <Listbox :class="width" as="div" :modelValue="modelValue" @update:model-value="$emit('update:modelValue', $event)">
+    <div class="relative">
+      <!-- not realy happy with using the headless ui just for having a non-native input-select field ( <ListboxButton> and <ListboxOptions> ) 
+      1. its impossible without hardcoding heights to mix native input fields and this fake
+      input selects ... i would prefer regular native input type select and get rid
+      of that dependency as it is not realy helpfull here -->
+
+      <!-- example code would be like this :
+      <select name="token" class="border-l-0 w-1/2">
+        <option value="eth">ETH</option>
+        <option value="dai">DAI</option>
+        <option value="gtc">GTC</option>
+        <option value="weth">WETH</option>
+      </select>
+      -->
+
+      <ListboxButton class="group w-full p-4 border border-grey-400 hover:border-grey-500">
+        <span class="block truncate text-left">{{ modelValue[label] }}</span>
         <span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none w-12">
           <ArrowBottom2Icon class="icon icon-primary" aria-hidden="true" />
         </span>
@@ -32,18 +31,17 @@
           class="
             absolute
             z-10
-            mt-1
             w-full
             bg-white
-            shadow-lg
-            max-h-60
-            rounded-md
-            py-1
-            text-base text-left
-            ring-1 ring-black ring-opacity-5
+            text-left
             overflow-auto
-            focus:outline-none
-            sm:text-sm
+            border border-grey-400
+            p-5
+            font-medium
+            bg-white
+            text-grey-400
+            uppercase
+            whitespace-nowrap
           "
         >
           <ListboxOption
@@ -53,21 +51,9 @@
             :value="option"
             v-slot="{ active, selected }"
           >
-            <li
-              :class="[
-                active ? 'text-white bg-grey-500' : 'text-gray-900',
-                'cursor-default select-none relative py-2 pl-3 pr-9',
-              ]"
-            >
-              <span :class="[selected ? 'font-semibold' : 'font-normal', 'block truncate']">
+            <li :class="[active ? 'text-grey-500' : '', 'cursor-pointer select-none relative']">
+              <span :class="[selected ? 'text-grey-500' : '', 'block truncate']">
                 {{ option[label] }}
-              </span>
-
-              <span v-if="selected" :class="['absolute inset-y-0 right-0 flex items-center pr-4 w-12']">
-                <CheckIcon
-                  :class="['icon icon-heavy', active ? 'stroke-white' : 'stroke-grey-400']"
-                  aria-hidden="true"
-                />
               </span>
             </li>
           </ListboxOption>
@@ -80,7 +66,7 @@
 <script lang="ts">
 import { defineComponent, PropType } from 'vue';
 import { Listbox, ListboxButton, /* ListboxLabel, */ ListboxOption, ListboxOptions } from '@headlessui/vue';
-import { CheckIcon, ArrowBottom2Icon } from '@fusion-icons/vue/interface';
+import { ArrowBottom2Icon } from '@fusion-icons/vue/interface';
 
 export default defineComponent({
   name: 'BaseSelect',
@@ -89,7 +75,6 @@ export default defineComponent({
     ListboxButton,
     /* ListboxLabel, */ ListboxOption,
     ListboxOptions,
-    CheckIcon,
     ArrowBottom2Icon,
   },
   props: {
@@ -99,6 +84,7 @@ export default defineComponent({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     options: { type: Array as PropType<Record<string, any>[]>, required: true }, // available options, must be array of objects with an `id` field
     label: { type: String, required: false, default: 'name' }, // option[label] is used as the string shown
+    width: { type: String, required: false, default: 'w-full' }, // input field width
   },
 });
 </script>

--- a/app/src/views/Cart.vue
+++ b/app/src/views/Cart.vue
@@ -1,102 +1,133 @@
 <template>
   <!-- Empty cart -->
   <div v-if="!txHash && cart.length === 0">
-    <div class="mt-10">Your cart is empty</div>
-    <button @click="pushRoute({ name: 'dgrants' })" class="btn btn-primary mx-auto mt-6">Browse Grants</button>
+    <BaseHeader :name="`My Cart (${cart.length})`" />
+
+    <div class="px-4 md:px-12">
+      <div class="py-8 border-b border-grey-100">
+        <div class="flex gap-x-4 justify-end">
+          <span>Your Cart is empty.</span>
+        </div>
+      </div>
+
+      <div class="mt-12">
+        <div class="flex gap-x-4 justify-end">
+          <button @click="pushRoute({ name: 'dgrants' })" class="btn">explore grants</button>
+        </div>
+      </div>
+    </div>
   </div>
 
   <!-- Cart has items and no checkout transaction -->
   <div v-else-if="!txHash">
     <BaseHeader :name="`My Cart (${cart.length})`" />
-    <!-- Cart toolbar -->
-    <div
-      class="flex justify-between max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 border-b border-grey-100 text-grey-400"
-    >
-      <div class="flex items-center justify-start">
-        <div @click="NOT_IMPLEMENTED('Share cart')" class="flex items-center justify-start cursor-pointer">
-          <ArrowToprightIcon class="icon-small icon-primary mr-2" /> Share cart
+
+    <!-- Action Nav / Cart Toolbar ( Share & Clear Cart -->
+    <div class="px-4 md:px-12 py-8 border-b border-grey-100">
+      <div class="flex flex-wrap gap-x-6 gap-y-4">
+        <div @click="NOT_IMPLEMENTED('Share cart')" class="flex items-center gap-x-2 cursor-pointer group">
+          <ArrowToprightIcon class="icon icon-small icon-primary" />
+          <span class="text-grey-400 group-hover:text-grey-500">Share</span>
+        </div>
+
+        <div @click="clearCart" class="flex items-center gap-x-2 cursor-pointer group ml-auto">
+          <CloseIcon class="icon icon-small icon-primary" />
+          <span class="text-grey-400 group-hover:text-grey-500">Clear</span>
         </div>
       </div>
-      <div @click="clearCart" class="flex items-center justify-end cursor-pointer">
-        <CloseIcon class="icon-small icon-primary mr-2" /> Clear cart
-      </div>
     </div>
-    <!-- Cart items -->
-    <div class="bg-white shadow sm:rounded-md max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <ul>
-        <!-- For each grant in the cart -->
-        <li v-for="item in cart" :key="item.grantId">
-          <div class="flex justify-between items-center border-b border-grey-100 py-10">
-            <!-- Logo and name -->
-            <div
-              class="flex items-center cursor-pointer"
-              @click="pushRoute({ name: 'dgrants-id', params: { id: item.id.toString() } })"
-            >
-              <img
-                class="h-12 w-12"
-                :src="grantMetadata[item.metaPtr]?.logoURI || 'src/assets/logo.svg'"
-                alt="Grant logo"
-              />
-              <p class="ml-4 text-sm text-left font-medium truncate max-w-lg">
-                {{ grantMetadata[item.metaPtr]?.name }}
-              </p>
-            </div>
 
-            <!-- Contribution info -->
-            <div class="flex space-x-2 items-center">
-              <!-- Contribution token and amount -->
-              <div class="flex">
-                <!-- We use a -1px right margin so overlapping borders don't make the border thicker -->
-                <BaseInput
-                  style="margin-right: -1px"
-                  :modelValue="item.contributionAmount"
-                  @update:modelValue="
-                    item.contributionAmount = Number($event);
-                    updateCart(item.grantId, item.contributionAmount);
-                  "
-                  type="number"
-                  width="w-36"
-                  :showBorder="false"
-                />
-                <BaseSelect
-                  :modelValue="item.contributionToken"
-                  @update:modelValue="
-                    item.contributionToken = $event;
-                    updateCart(item.grantId, item.contributionToken.address);
-                  "
-                  :options="SUPPORTED_TOKENS"
-                  label="symbol"
-                />
+    <!-- Cart Items -->
+    <div v-for="item in cart" :key="item.grantId" class="px-4 md:px-12">
+      <div class="py-8 border-b border-grey-100">
+        <div class="grid grid-flow-col items-center gap-x-8">
+          <div>
+            <div class="grid grid-cols-4 items-center gap-x-8 gap-y-4">
+              <!-- image -->
+              <div class="col-span-4 lg:col-span-1">
+                <figure class="max-w-lg">
+                  <img
+                    class="shadow-light"
+                    :src="grantMetadata[item.metaPtr]?.logoURI || 'src/assets/placeholder_grant.svg'"
+                  />
+                </figure>
               </div>
-
-              <!-- Match estimate -->
-              <!-- TODO use real match estimates -->
-              <div class="flex-none hidden md:block px-4">
-                <p v-if="true" class="text-sm text-left text-grey-300">not in an active round</p>
-                <p v-else class="text-sm text-left text-grey-500">USD estimated matching</p>
+              <!-- text -->
+              <div class="col-span-4 lg:col-span-1">
+                <div>{{ grantMetadata[item.metaPtr]?.name }}</div>
               </div>
+              <!-- input -->
+              <div class="col-span-4 lg:col-span-1">
+                <div class="flex">
+                  <BaseInput
+                    :modelValue="item.contributionAmount"
+                    @update:modelValue="
+                      item.contributionAmount = Number($event);
+                      updateCart(item.grantId, item.contributionAmount);
+                    "
+                    type="number"
+                    width="w-1/2"
+                    customcss="border-r-0"
+                  />
 
-              <!-- Delete from cart -->
-              <div>
-                <CloseIcon @click="removeFromCart(item.grantId)" class="icon-small icon-primary" />
+                  <BaseSelect
+                    :modelValue="item.contributionToken"
+                    @update:modelValue="
+                      item.contributionToken = $event;
+                      updateCart(item.grantId, item.contributionToken.address);
+                    "
+                    :options="SUPPORTED_TOKENS"
+                    label="symbol"
+                    width="w-1/2"
+                  />
+                </div>
+              </div>
+              <!-- matching -->
+              <div class="col-span-4 lg:col-span-1">
+                <div class="text-grey-400 text-left lg:text-right">
+                  <!-- TODO use real match estimates -->
+                  <p v-if="true">not in an active round</p>
+                  <p v-else>USD estimated matching</p>
+                </div>
               </div>
             </div>
           </div>
-        </li>
-      </ul>
+
+          <div class="justify-self-end">
+            <CloseIcon @click="removeFromCart(item.grantId)" class="icon icon-small icon-primary cursor-pointer" />
+          </div>
+        </div>
+      </div>
     </div>
 
     <!-- Checkout -->
-    <div class="bg-white shadow sm:rounded-md max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-right">
-      <div class="border-b border-grey-100 py-8">
-        <span class="text-grey-300">Contributing:</span> {{ cartSummaryString }}
+
+    <div class="px-4 md:px-12">
+      <div class="py-8 border-b border-grey-100">
+        <div class="flex gap-x-4 justify-end">
+          <span class="text-grey-400">Contributing:</span>
+          <span>{{ cartSummaryString }}</span>
+        </div>
       </div>
-      <div class="border-b border-grey-100 py-8"><span class="text-grey-300">Equivalent to:</span> TODO USD</div>
-      <div class="border-b border-grey-100 py-8">
-        <span class="text-grey-300">Estimated matching value:</span> TODO USD
+
+      <div class="py-8 border-b border-grey-100">
+        <div class="flex gap-x-4 justify-end">
+          <span class="text-grey-400">Equivalent to:</span>
+          <span>TODO</span>
+        </div>
       </div>
-      <div class="py-8 flex justify-end">
-        <button @click="executeCheckout" class="btn">Checkout</button>
+
+      <div class="py-8 border-b border-grey-100">
+        <div class="flex gap-x-4 justify-end">
+          <span class="text-grey-400">Estimated matching value:</span>
+          <span>TODO</span>
+        </div>
+      </div>
+
+      <div class="mt-12 mb-12">
+        <div class="flex gap-x-4 justify-end">
+          <button @click="executeCheckout" class="btn">checkout</button>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
i worked on the cart to get my ui in, and everything worked fine. this is a mandatory pull request and should get merged asap to continue working on it ( usdt / matching and so on ) ...

**anyway there is 2 issue here we need to be aware of and fix :**

the cart uses  `<BaseInput>` and `<BaseSelect>` Components (pre-design-created)  what i had to tweak. the `<BaseSelect>` uses some non-native fake-select-input-fields, what are hard to combine with regular native `<input>` ( see different heights on some resolutions )

<img width="507" alt="Bildschirmfoto 2021-09-03 um 19 44 16" src="https://user-images.githubusercontent.com/569641/132048916-92fb44bb-326d-4008-b5d1-64519574c52a.png">

Input Fields are always hard to Controll - especialy when you work with paddings, and percentage based sizes - so its not a good idea to mix different approaches to style it. I would 100% prefer if we can go a step back and remove that headless ui components and use regular html `<select>` what would remove that issue and be less overhead / complicated code. i can not do this - as its technical to complex ( but i put an example in the .vue file how i would like to use it if possible ) 

Issue2  is, that i can not see the grants titles in every item in a cart until i update the input field ( eg from 5 to 6 DAI ) . this might need to be inspected and has probably todo with ipfs ?

we are getting a bit closer here in design from what i had in mind.

<img width="1722" alt="Bildschirmfoto 2021-09-03 um 19 50 23" src="https://user-images.githubusercontent.com/569641/132049430-f0a0e481-e79a-4650-ae79-e0ed8872f290.png">

