### PR TITLE
improved grants detail view

### DIFF
--- a/app/src/components/GrantDetailsRow.vue
+++ b/app/src/components/GrantDetailsRow.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="border-b border-grey-100 grid grid-cols-1 md:grid-cols-2 gap-x-8">
     <!--grid:left (img)-->
-    <div class="bg-pink">
+    <div>
       <img class="shadow-light object-cover h-full" :src="logoURI || '/src/assets/placeholder_grant.svg'" />
     </div>
 

--- a/app/src/components/GrantDetailsRow.vue
+++ b/app/src/components/GrantDetailsRow.vue
@@ -1,89 +1,79 @@
 <template>
-  <div class="border-b border-grey-100">
-    <div class="grid grid-cols-4 gap-0">
-      <!-- img -->
-      <div class="col-span-4 md:col-span-2 shadow-light flex">
-        <img class="m-auto" :src="logoURI || '/src/assets/logo.svg'" />
-      </div>
-      <div class="col-span-4 md:col-span-2 grid grid-cols-12 pt-8">
-        <!-- raised, contract, round, matching -->
-        <div class="text-center xl:text-left col-span-12 mb-8 xl:col-span-5 xl:col-start-2">
-          <div class="px-4 xl:px-0 xl:pt-2">
-            <div><span class="text-grey-400 mr-4">Raised:</span>{{ totalRaised }}</div>
-            <div>
-              <span class="text-grey-400 mr-4">Address:</span>
-              <a
-                class="link"
-                :href="`https://etherscan.io/address/${payoutAddress}`"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {{ formatAddress(payoutAddress) }}
-              </a>
-            </div>
-            <div class="xl:pt-6">
-              <span class="text-grey-400 mr-4">In Round:</span>
+  <div class="border-b border-grey-100 grid grid-cols-1 md:grid-cols-2 gap-x-8">
+    <!--grid:left (img)-->
+    <div class="bg-pink">
+      <img class="shadow-light object-cover h-full" :src="logoURI || '/src/assets/placeholder_grant.svg'" />
+    </div>
+
+    <!--grid:right (txt)-->
+    <div class="my-6">
+      <!--subgrid-->
+      <div class="grid grid-cols-1 xl:grid-cols-2 gap-8">
+        <!--subgrid:left (raised, contract, round, matching )-->
+        <div class="">
+          <!-- raised -->
+          <div><span class="text-grey-400 mr-4">Raised:</span>{{ totalRaised }}</div>
+
+          <!--contract-->
+          <div>
+            <span class="text-grey-400 mr-4">Contract:</span>
+            <a
+              class="link"
+              :href="`https://etherscan.io/address/${payoutAddress}`"
+              target="_blank"
+              rel="noopener noreferrer"
+              >{{ formatAddress(payoutAddress) }}</a
+            >
+          </div>
+
+          <!--round-->
+          <div>
+            <span class="text-grey-400 mr-4">In Round:</span>
+            <span v-for="(round, index) in roundDetails" :key="index">
+              {{ round.name }}<span v-if="index + 1 < roundDetails.length">, </span>
+            </span>
+          </div>
+
+          <!--matching-->
+          <div>
+            <span class="text-grey-400 mr-4">Matching:</span>
+            <span v-for="(round, index) in roundDetails" :key="index">
+              {{ round.matching }} {{ round.matchingToken.symbol }}
+              <span v-if="index + 1 < roundDetails.length">, </span>
+            </span>
+          </div>
+        </div>
+
+        <!--subgrid:right ( donate button, matching example )-->
+        <div class="pr-12">
+          <!-- button -->
+          <div class="text-right xl:flex xl:justify-end">
+            <button v-if="isInCart(grant?.id)" @click="removeFromCart(grant?.id)" class="btn in-cart btn-primary">
+              <CartIcon class="icon-small" />Remove
+            </button>
+
+            <button v-else @click="addToCart(grant?.id)" class="btn btn-primary">
+              <CartIcon class="icon-small" />Add
+            </button>
+          </div>
+
+          <!-- matching example -->
+          <div class="mt-4">
+            <div class="xl:text-right">
+              10 {{ roundDetails[0] ? roundDetails[0].donationToken.symbol : '' }} ≈
               <span v-for="(round, index) in roundDetails" :key="index">
-                {{ round.name }}<span v-if="index + 1 < roundDetails.length">, </span>
-              </span>
-            </div>
-            <div>
-              <span class="text-grey-400 mr-4">Matching:</span>
-              <span v-for="(round, index) in roundDetails" :key="index">
-                {{ round.matching }} {{ round.matchingToken.symbol
+                {{ round.prediction10 }} {{ round.matchingToken.symbol
                 }}<span v-if="index + 1 < roundDetails.length">, </span>
               </span>
+              Matching
             </div>
-          </div>
-        </div>
-        <!-- add to cart, matching example -->
-        <div class="text-center xl:text-left col-span-12 mb-8 xl:col-span-5 xl:col-end-12">
-          <div class="px-4 xl:px-0 xl:text-right mb-8 xl:mb-0">
-            <div class="flex justify-center mb-6 xl:justify-end">
-              <!-- when item in cart add class "in-cart" + text in span "remove from cart"-->
-              <button v-if="isInCart(grant?.id)" @click="removeFromCart(grant?.id)" class="btn btn-primary">
-                <CartIcon class="icon-small" />
-                Remove from Cart
-              </button>
-              <button v-else @click="addToCart(grant?.id)" class="btn btn-primary">
-                <CartIcon class="icon-small" />
-                Add to Cart
-              </button>
-            </div>
-
-            <div>
-              <div>
-                10 {{ roundDetails[0] ? roundDetails[0].donationToken.symbol : '' }} ≈
-                <span v-for="(round, index) in roundDetails" :key="index">
-                  {{ round.prediction10 }} {{ round.matchingToken.symbol
-                  }}<span v-if="index + 1 < roundDetails.length">, </span>
-                </span>
-                Matching
-              </div>
-              <div>
-                100 {{ roundDetails[0] ? roundDetails[0].donationToken.symbol : '' }} ≈
-                <span v-for="(round, index) in roundDetails" :key="index">
-                  {{ round.prediction100 }} {{ round.matchingToken.symbol
-                  }}<span v-if="index + 1 < roundDetails.length">, </span>
-                </span>
-                Matching
-              </div>
-            </div>
-            <div class="flex justify-center mb-6 xl:justify-end">
-              <!-- allow extra buttons to be defined in the parent -->
-              <slot name="extraButtons"></slot>
-            </div>
-          </div>
-        </div>
-        <div class="text-left col-span-11 col-start-2">
-          <div class="flex flex-wrap gap-x-6 gap-y-4">
-            <!-- allow extra buttons to be defined in the parent -->
-            <slot name="extraLinks"></slot>
-
-            <!-- Share -->
-            <div class="flex items-center gap-x-2 cursor-pointer group">
-              <ShareIcon class="icon-primary stroke-2 w-9" />
-              <span class="text-grey-400 group-hover:text-grey-500">Share</span>
+            <div class="xl:text-right">
+              100 {{ roundDetails[0] ? roundDetails[0].donationToken.symbol : '' }} ≈
+              <span v-for="(round, index) in roundDetails" :key="index">
+                {{ round.prediction100 }} {{ round.matchingToken.symbol
+                }}<span v-if="index + 1 < roundDetails.length">, </span>
+              </span>
+              Matching
             </div>
           </div>
         </div>
@@ -102,11 +92,10 @@ import { Grant, GrantsRoundDetails } from '@dgrants/types';
 import { formatAddress } from 'src/utils/utils';
 // --- Components/icons ---
 import { Cart2Icon as CartIcon } from '@fusion-icons/vue/interface';
-import { ArrowToprightIcon as ShareIcon } from '@fusion-icons/vue/interface';
 
 export default defineComponent({
   name: 'GrantDetailsRow',
-  components: { CartIcon, ShareIcon },
+  components: { CartIcon },
   props: {
     grant: { type: Object as PropType<Grant>, required: true },
     roundDetails: { type: Array as PropType<GrantsRoundDetails[]>, required: true },

--- a/app/src/components/GrantDetailsRow.vue
+++ b/app/src/components/GrantDetailsRow.vue
@@ -6,76 +6,65 @@
     </div>
 
     <!--grid:right (txt)-->
-    <div class="my-6">
-      <!--subgrid-->
-      <div class="grid grid-cols-1 xl:grid-cols-2 gap-8">
-        <!--subgrid:left (raised, contract, round, matching )-->
-        <div class="">
-          <!-- raised -->
-          <div><span class="text-grey-400 mr-4">Raised:</span>{{ totalRaised }}</div>
+    <div class="my-6 px-8 md:px-0">
+      <!-- raised -->
+      <div><span class="text-grey-400 mr-4">Raised:</span>{{ totalRaised }}</div>
 
-          <!--contract-->
-          <div>
-            <span class="text-grey-400 mr-4">Contract:</span>
-            <a
-              class="link"
-              :href="`https://etherscan.io/address/${payoutAddress}`"
-              target="_blank"
-              rel="noopener noreferrer"
-              >{{ formatAddress(payoutAddress) }}</a
-            >
-          </div>
+      <!--contract-->
+      <div>
+        <span class="text-grey-400 mr-4">Contract:</span>
+        <a
+          class="link"
+          :href="`https://etherscan.io/address/${payoutAddress}`"
+          target="_blank"
+          rel="noopener noreferrer"
+          >{{ formatAddress(payoutAddress) }}</a
+        >
+      </div>
 
-          <!--round-->
-          <div>
-            <span class="text-grey-400 mr-4">In Round:</span>
-            <span v-for="(round, index) in roundDetails" :key="index">
-              {{ round.name }}<span v-if="index + 1 < roundDetails.length">, </span>
-            </span>
-          </div>
+      <!--round-->
+      <div>
+        <span class="text-grey-400 mr-4">In Round:</span>
+        <span v-for="(round, index) in roundDetails" :key="index">
+          {{ round.name }}<span v-if="index + 1 < roundDetails.length">, </span>
+        </span>
+      </div>
 
-          <!--matching-->
-          <div>
-            <span class="text-grey-400 mr-4">Matching:</span>
-            <span v-for="(round, index) in roundDetails" :key="index">
-              {{ round.matching }} {{ round.matchingToken.symbol }}
-              <span v-if="index + 1 < roundDetails.length">, </span>
-            </span>
-          </div>
+      <!--matching-->
+      <div>
+        <span class="text-grey-400 mr-4">Matching:</span>
+        <span v-for="(round, index) in roundDetails" :key="index">
+          {{ round.matching }} {{ round.matchingToken.symbol }}
+          <span v-if="index + 1 < roundDetails.length">, </span>
+        </span>
+      </div>
+
+      <!-- button -->
+      <div class="mt-8">
+        <button v-if="isInCart(grant?.id)" @click="removeFromCart(grant?.id)" class="btn in-cart btn-primary">
+          <CartIcon class="icon-small" />Remove
+        </button>
+
+        <button v-else @click="addToCart(grant?.id)" class="btn btn-primary"><CartIcon class="icon-small" />Add</button>
+      </div>
+
+      <!-- matching example -->
+      <div class="mt-4">
+        <div>
+          10 {{ roundDetails[0] ? roundDetails[0].donationToken.symbol : '' }} ≈
+          <span v-for="(round, index) in roundDetails" :key="index">
+            {{ round.prediction10 }} {{ round.matchingToken.symbol
+            }}<span v-if="index + 1 < roundDetails.length">, </span>
+          </span>
+          Matching
         </div>
-
-        <!--subgrid:right ( donate button, matching example )-->
-        <div class="pr-12">
-          <!-- button -->
-          <div class="text-right xl:flex xl:justify-end">
-            <button v-if="isInCart(grant?.id)" @click="removeFromCart(grant?.id)" class="btn in-cart btn-primary">
-              <CartIcon class="icon-small" />Remove
-            </button>
-
-            <button v-else @click="addToCart(grant?.id)" class="btn btn-primary">
-              <CartIcon class="icon-small" />Add
-            </button>
-          </div>
-
-          <!-- matching example -->
-          <div class="mt-4">
-            <div class="xl:text-right">
-              10 {{ roundDetails[0] ? roundDetails[0].donationToken.symbol : '' }} ≈
-              <span v-for="(round, index) in roundDetails" :key="index">
-                {{ round.prediction10 }} {{ round.matchingToken.symbol
-                }}<span v-if="index + 1 < roundDetails.length">, </span>
-              </span>
-              Matching
-            </div>
-            <div class="xl:text-right">
-              100 {{ roundDetails[0] ? roundDetails[0].donationToken.symbol : '' }} ≈
-              <span v-for="(round, index) in roundDetails" :key="index">
-                {{ round.prediction100 }} {{ round.matchingToken.symbol
-                }}<span v-if="index + 1 < roundDetails.length">, </span>
-              </span>
-              Matching
-            </div>
-          </div>
+        <div>
+          100 {{ roundDetails[0] ? roundDetails[0].donationToken.symbol : '' }} ≈
+          <span v-for="(round, index) in roundDetails" :key="index">
+            {{ round.prediction100 }} {{ round.matchingToken.symbol
+            }}<span v-if="index + 1 < roundDetails.length">, </span>
+          </span>
+          Matching
         </div>
       </div>
     </div>

--- a/app/src/views/GrantRegistryGrantDetail.vue
+++ b/app/src/views/GrantRegistryGrantDetail.vue
@@ -17,20 +17,30 @@
         :lastPath="lastGrant"
       />
 
+      <!-- grant details row ( image + raised, address, in round, matchin, add to cart button ) -->
       <GrantDetailsRow
         :grant="grant"
         :logoURI="grantMetadata?.logoURI"
         :payoutAddress="grant.payee"
         :totalRaised="grantContributionsTotal"
         :roundDetails="grantContributionsByRound"
-      >
-        <template v-slot:extraLinks>
-          <div v-if="isOwner" @click="enableEdit()" class="flex items-center gap-x-2 cursor-pointer group">
-            <EditIcon class="icon-primary stroke-2 w-9" />
-            <span class="text-grey-400 group-hover:text-grey-500">Edit Grant</span>
+      />
+
+      <!-- Interactions Bar for Share, Collection, Edit and so on  -->
+      <div class="px-4 md:px-12 py-8 border-b border-grey-100">
+        <div class="flex flex-wrap gap-x-6 gap-y-4">
+          <!--share : todo on click what to do-->
+          <div class="flex items-center gap-x-2 cursor-pointer group ml-auto">
+            <ShareIcon class="icon icon-primary icon-small" />
+            <span class="text-grey-400 group-hover:text-grey-500">Share</span>
           </div>
-        </template>
-      </GrantDetailsRow>
+          <!--edit for owner-->
+          <div v-if="isOwner" @click="enableEdit()" class="flex items-center gap-x-2 cursor-pointer group">
+            <EditIcon class="icon icon-primary icon-small" />
+            <span class="text-grey-400 group-hover:text-grey-500">Edit</span>
+          </div>
+        </div>
+      </div>
 
       <SectionHeader title="Description" />
 
@@ -231,7 +241,8 @@ import GrantDetailsRow from 'src/components/GrantDetailsRow.vue';
 import TransactionStatus from 'src/components/TransactionStatus.vue';
 import { CLR, fetch, InitArgs, linear } from '@dgrants/dcurve';
 // --- Icons ---
-import { Edit2Icon as EditIcon } from '@fusion-icons/vue/interface';
+import { ArrowToprightIcon as ShareIcon } from '@fusion-icons/vue/interface';
+import { Edit3Icon as EditIcon } from '@fusion-icons/vue/interface';
 
 function useGrantDetail() {
   // --- get current state ---
@@ -607,6 +618,7 @@ export default defineComponent({
     BaseFilterNav,
     GrantDetailsRow,
     EditIcon,
+    ShareIcon,
     TransactionStatus,
   },
   setup() {


### PR DESCRIPTION
- rewrote that grantdetailrow from scratch for slicker code and especially for bens concerns regarding to big grant-image  
- removed v-slot from GrantDetailsRow for share/edit buttons as i outsourced these to a dedicated navbar in the GrantRegistryGrantDetail.vue for better scalability of more interactions and a simpler codebase.

https://user-images.githubusercontent.com/569641/132556626-74e6717a-86bd-4c05-83a0-5367fb25b65b.mov
