### PR TITLE
fix: Fixes circular dependency issue on brorand

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -25,7 +25,6 @@
     "assert": "^2.0.0",
     "bnc-notify": "^1.9.1",
     "bnc-onboard": "~1.30.0",
-    "brorand": "^1.1.0",
     "browserify-zlib": "^0.2.0",
     "crypto-browserify": "^3.12.0",
     "ethers": "^5.4.6",
@@ -69,8 +68,5 @@
   },
   "volta": {
     "extends": "../package.json"
-  },
-  "resolutions": {
-    "brorand": "https://github.com/buu700/brorand"
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -25,6 +25,7 @@
     "assert": "^2.0.0",
     "bnc-notify": "^1.9.1",
     "bnc-onboard": "~1.30.0",
+    "brorand": "^1.1.0",
     "browserify-zlib": "^0.2.0",
     "crypto-browserify": "^3.12.0",
     "ethers": "^5.4.6",
@@ -68,5 +69,8 @@
   },
   "volta": {
     "extends": "../package.json"
+  },
+  "resolutions": {
+    "brorand": "https://github.com/buu700/brorand"
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "dev": "vite",
-    "build": "vue-tsc --noEmit && vite build",
+    "build": "git rev-parse --short HEAD && vue-tsc --noEmit && vite build",
     "serve": "vite preview",
     "test:unit": "vue-cli-service test:unit",
     "test:e2e": "vue-cli-service test:e2e",

--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
   "volta": {
     "node": "14.17.4",
     "yarn": "1.22.10"
+  },
+  "resolutions": {
+    "brorand": "https://github.com/buu700/brorand"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5533,7 +5533,11 @@ braces@^3.0.1, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-brorand@^1.0.1, brorand@^1.1.0:
+brorand@^1.0.1, "brorand@https://github.com/buu700/brorand":
+  version "1.1.0"
+  resolved "https://github.com/buu700/brorand#1b8c372b3c78bd5287728c1d5b4bf9cb8b708196"
+
+brorand@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
@@ -13422,6 +13426,7 @@ minipass-fetch@^1.3.0, minipass-fetch@^1.3.2:
   resolved "https://registry.yarnpkg.com/minipass-fetch/-/minipass-fetch-1.3.4.tgz#63f5af868a38746ca7b33b03393ddf8c291244fe"
   integrity sha512-TielGogIzbUEtd1LsjZFs47RWuHHfhl6TiCx1InVxApBAmQ8bL0dL5ilkLGcRvuyW/A9nE+Lvn855Ewz8S0PnQ==
   dependencies:
+    encoding "^0.1.12"
     minipass "^3.1.0"
     minipass-sized "^1.0.3"
     minizlib "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5533,14 +5533,9 @@ braces@^3.0.1, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-brorand@^1.0.1, "brorand@https://github.com/buu700/brorand":
+brorand@^1.0.1, brorand@^1.1.0, "brorand@https://github.com/buu700/brorand":
   version "1.1.0"
   resolved "https://github.com/buu700/brorand#1b8c372b3c78bd5287728c1d5b4bf9cb8b708196"
-
-brorand@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
-  integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
 browser-process-hrtime@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR forces the use of an alternative version of `brorand` which does not have a circular dependency (https://github.com/buu700/brorand) on `crypto`

--

Fixes: #178

--

Tested locally and everything now loads after a `yarn build`