### PR TITLE
Adding base dockerfile for building in Fleek

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:slim
+
+RUN apt update
+RUN apt install git -y
+
+RUN curl https://get.volta.sh | bash
+
+RUN export VOLTA_HOME=$HOME/.volta
+RUN export PATH=$VOLTA_HOME/bin:$PATH


### PR DESCRIPTION
This is the base docker container that we are using to build in Fleek.

To build this I use:
```
docker build -f ./app/Dockerfile -t phutchins/volta-base:0.0.1 .
```

then to push to docker hub:
```
docker push phutchins/volta-base:0.0.1
```

We should and will create an org for dGTC and push to that at some point instead of my org.