### PR TITLE
feat: show DAI-equivalent donation amount on cart page

### DIFF
--- a/app/src/store/cart.ts
+++ b/app/src/store/cart.ts
@@ -13,6 +13,7 @@ import {
   ETH_ADDRESS,
   GRANT_ROUND_MANAGER_ABI,
   GRANT_ROUND_MANAGER_ADDRESS,
+  SUPPORTED_TOKENS,
   SUPPORTED_TOKENS_MAPPING,
   WAD,
   WETH_ADDRESS,
@@ -60,7 +61,8 @@ const toHex = (val: BigNumberish) => BigNumber.from(val).toHexString();
 
 // --- State ---
 const lsCart = ref<CartItemOptions[]>([]); // localStorage cart
-const cart = ref<CartItem[]>([]);
+const cart = ref<CartItem[]>([]); // source of truth for what's in the user's cart
+const quotes = ref<Record<string, number>>({}); // mapping from token address to DAI exchange rate, i.e. multiple token quantity by the exchange rate to get the value in DAI
 
 // --- Composition function for state management ---
 export default function useCartStore() {
@@ -265,6 +267,28 @@ export default function useCartStore() {
     return { swaps, donations: fixDonationRoundingErrors(donations), deadline: Math.floor(nowPlus20Minutes / 1000) };
   }
 
+  /**
+   * @notice Fetches quotes based on the users cart
+   * @dev For max accuracy, this should be run each time the user edits their cart with the actual cart amounts, but in
+   * reality this will be accurate enough if we just run it once with default amounts and save the results, because
+   * the Uniswap pools have sufficient liquid for all SUPPORTED_TOKENS
+   */
+  async function fetchQuotes() {
+    // TODO use multicall for better performance + fewer RPC requests
+    const _quotes = await Promise.all(
+      SUPPORTED_TOKENS.map(async (token) => {
+        if (token.symbol === 'DAI' || token.symbol === 'USDC') return { token, rate: 1 };
+        const path = SWAP_PATHS[<keyof typeof SWAP_PATHS>token.address];
+        const amountIn = parseUnits('1', token.decimals); // for simplicity, use a value of 1 token for getting quotes
+        const amountOut = await quoteExactInput(path, amountIn); // as raw BigNumber
+        return { token, rate: Number(formatUnits(amountOut, token.decimals)) };
+      })
+    );
+    console.log('quotes.value: ', quotes.value);
+    _quotes.forEach((quote) => (quotes.value[quote.token.address] = quote.rate));
+    console.log('quotes.value: ', quotes.value);
+  }
+
   // --- Getters ---
   /**
    * @notice Returns true if the provided grantId is in the cart, false otherwise
@@ -306,13 +330,16 @@ export default function useCartStore() {
     // WARNING: Be careful -- the `cart` ref is directly exposed so it can be edited by v-model, so just make
     // sure to call `updateCart()` with the appropriate inputs whenever the `cart` ref is modified
     cart,
+    quotes: computed(() => quotes.value),
     // Getters
     cartItemsCount: computed(() => cart.value.length),
-    cartSummaryString,
-    // Mutations
+    cartSummary: computed(() => cartSummary.value),
+    cartSummaryString: computed(() => cartSummaryString.value),
+    // Actions / Mutations
     addToCart,
     checkout,
     clearCart,
+    fetchQuotes,
     initializeCart,
     isInCart,
     removeFromCart,

--- a/app/src/utils/utils.ts
+++ b/app/src/utils/utils.ts
@@ -22,7 +22,8 @@ export function isDefined(val: unknown) {
 export function formatNumber(value: BigNumberish, decimals: number): string {
   // `BigNumber.from()` can't take decimal inputs
   value = typeof value === 'number' || typeof value === 'string' ? Number(value) : BigNumber.from(value);
-  return commify(parseFloat(String(value)).toFixed(decimals));
+  // Return value with minimum number of decimals shown, e.g. return '123' if input is 123.00
+  return commify(parseFloat(Number(value).toFixed(decimals)));
 }
 
 // Expects a unix timestamp and will return a human readable message of how far in the past/future it is

--- a/app/src/views/Cart.vue
+++ b/app/src/views/Cart.vue
@@ -112,7 +112,7 @@
       <div class="py-8 border-b border-grey-100">
         <div class="flex gap-x-4 justify-end">
           <span class="text-grey-400">Equivalent to:</span>
-          <span>{{ formatNumber(equivalentContributionAmount, 2) }} DAI</span>
+          <span>~{{ formatNumber(equivalentContributionAmount, 2) }} DAI</span>
         </div>
       </div>
 


### PR DESCRIPTION
Resolves two-thirds of #176

The "17,278.11 DAI" portion of the screenshot below is what this PR adds. Prior to this PR, that just said "TODO"

For now we hardcode DAI but in the future we'll need to show this based on the GrantRoundManager's `donationToken`. I thought about creating an issue for this, but I a meta "Post-POC improvements" issue would be cleaner, to avoid having tons of small issues for each TODO + simplify triaging/prioritizing after the POC. @apbendi thoughts on this? 

![image](https://user-images.githubusercontent.com/17163988/132860024-30b4e947-efec-43c5-8f3a-95ef70fedb06.png)
