### PR TITLE
fix: change from history to hash routing for IPFS support

### DIFF
--- a/app/src/router/index.ts
+++ b/app/src/router/index.ts
@@ -4,7 +4,7 @@
  * generates a separate chunk (e.g. `about.[hash].js`) for this route which is lazy-loaded when the route is visited
  */
 
-import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router';
+import { createRouter, createWebHashHistory, RouteRecordRaw } from 'vue-router';
 import Home from '../views/Home.vue';
 
 // For info on using Vue Router with the Composition API, see https://next.router.vuejs.org/guide/advanced/composition-api.html
@@ -32,7 +32,7 @@ const routes: Array<RouteRecordRaw> = [
 
 const router = createRouter({
   // If app is not hosted at the domain root, make sure to pass the `base` input here: https://next.router.vuejs.org/api/#parameters
-  history: createWebHistory(),
+  history: createWebHashHistory(),
   routes,
 });
 


### PR DESCRIPTION
I don't think we have an associated issue, but this changes the router from history to hash mode, where has mode is "Useful for web applications with no host (e.g. file://) or when configuring a server to handle any URL isn't an option"

Relevant docs here: https://next.router.vuejs.org/api/#parameters