### PR TITLE
richard-random-fixes-2

### DIFF
--- a/app/src/components/BaseInput.vue
+++ b/app/src/components/BaseInput.vue
@@ -4,6 +4,7 @@
       v-model="val"
       @input="onInput"
       :class="[customcss ? customcss : '']"
+      class="h-16"
       :id="id"
       :name="id"
       :required="required"

--- a/app/src/components/BaseSelect.vue
+++ b/app/src/components/BaseSelect.vue
@@ -1,5 +1,11 @@
 <template>
-  <Listbox :class="width" as="div" :modelValue="modelValue" @update:model-value="$emit('update:modelValue', $event)">
+  <Listbox
+    :class="width"
+    class="h-16"
+    as="div"
+    :modelValue="modelValue"
+    @update:model-value="$emit('update:modelValue', $event)"
+  >
     <div class="relative">
       <!-- not realy happy with using the headless ui just for having a non-native input-select field ( <ListboxButton> and <ListboxOptions> ) 
       1. its impossible without hardcoding heights to mix native input fields and this fake
@@ -15,7 +21,7 @@
       </select>
       -->
 
-      <ListboxButton class="group w-full p-4 border border-grey-400 hover:border-grey-500">
+      <ListboxButton class="group w-full p-4 border border-grey-400 hover:border-grey-500 h-16">
         <span class="block truncate text-left">{{ modelValue[label] }}</span>
         <span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none w-12">
           <ArrowBottom2Icon class="icon icon-primary" aria-hidden="true" />

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -19,8 +19,44 @@
     scroll-behavior: smooth;
   }
 
+  .bn-notify-custom {
+    margin-left: 0px;
+  }
+
+  /*container holding all of the notifications*/
   .bn-notify-custom .bn-notify-notification {
     font-family: Source Code Pro, monospace;
+    border-radius: 0px !important;
+    padding-left: 0px;
+    padding-bottom: 10px;
+    font-size: 80%;
+    line-height: 130%;
+    @apply bg-grey-500 text-white;
+    display: block;
+  }
+
+  .bn-notify-custom .bn-notify-notification::after {
+    padding-left: 1em;
+    content: "_";
+    @apply text-white;
+    animation: blink-animation 700ms infinite;
+  }
+
+  @keyframes blink-animation {
+    0% {
+      opacity: 0;
+    }
+    50% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+    }
+  }
+
+  /* icons  */
+  .bn-notify-custom .bn-notify-notification-status-icon {
+    display: none;
   }
 
   h1 {

--- a/app/src/views/Cart.vue
+++ b/app/src/views/Cart.vue
@@ -25,10 +25,25 @@
     <!-- Action Nav / Cart Toolbar ( Share & Clear Cart -->
     <div class="px-4 md:px-12 py-8 border-b border-grey-100">
       <div class="flex flex-wrap gap-x-6 gap-y-4">
-        <div @click="NOT_IMPLEMENTED('Share cart')" class="flex items-center gap-x-2 cursor-pointer group">
-          <ArrowToprightIcon class="icon icon-small icon-primary" />
-          <span class="text-grey-400 group-hover:text-grey-500">Share</span>
-        </div>
+        <!-- rudimentary tweet function -->
+        <!-- needs to get replaced with some real "share cart functionality" later on -->
+
+        <a
+          target="_blank"
+          rel="noreferrer noopener"
+          :href="
+            'https://twitter.com/intent/tweet' +
+            '?text=' +
+            encodeURIComponent('Checkout ' + grantMetadata?.name + ' at Gitcoins Decentral Grants App!') +
+            '&url=' +
+            encodeURIComponent('https://grants.gtcdao.net')
+          "
+        >
+          <div class="flex items-center gap-x-2 cursor-pointer group">
+            <TwitterIcon class="icon icon-small icon-primary" />
+            <span class="text-grey-400 group-hover:text-grey-500">Tweet</span>
+          </div>
+        </a>
 
         <div @click="clearCart" class="flex items-center gap-x-2 cursor-pointer group ml-auto">
           <CloseIcon class="icon icon-small icon-primary" />
@@ -149,7 +164,7 @@
 <script lang="ts">
 // --- External Imports ---
 import { computed, defineComponent, onMounted, ref } from 'vue';
-import { ArrowToprightIcon, CloseIcon } from '@fusion-icons/vue/interface';
+import { TwitterIcon, CloseIcon } from '@fusion-icons/vue/interface';
 // --- Component Imports ---
 import BaseHeader from 'src/components/BaseHeader.vue';
 import BaseInput from 'src/components/BaseInput.vue';
@@ -204,7 +219,7 @@ export default defineComponent({
     BaseInput,
     BaseSelect,
     TransactionStatus,
-    ArrowToprightIcon,
+    TwitterIcon,
     CloseIcon,
     LoadingSpinner,
   },

--- a/app/src/views/GrantRegistryGrantDetail.vue
+++ b/app/src/views/GrantRegistryGrantDetail.vue
@@ -298,7 +298,7 @@ import TransactionStatus from 'src/components/TransactionStatus.vue';
 import LoadingSpinner from 'src/components/LoadingSpinner.vue';
 import { CLR, fetch, InitArgs, linear } from '@dgrants/dcurve';
 // --- Icons ---
-import { TwitterIcon as TwitterIcon } from '@fusion-icons/vue/interface';
+import { TwitterIcon } from '@fusion-icons/vue/interface';
 import { Edit3Icon as EditIcon } from '@fusion-icons/vue/interface';
 
 function useGrantDetail() {

--- a/app/src/views/GrantRegistryGrantDetail.vue
+++ b/app/src/views/GrantRegistryGrantDetail.vue
@@ -26,14 +26,28 @@
         :roundDetails="grantContributionsByRound"
       />
 
-      <!-- Interactions Bar for Share, Collection, Edit and so on  -->
+      <!-- Interactions Bar for Tweet, Collection, Edit and so on  -->
       <div class="px-4 md:px-12 py-8 border-b border-grey-100">
         <div class="flex flex-wrap gap-x-6 gap-y-4">
-          <!--share : todo on click what to do-->
-          <div class="flex items-center gap-x-2 cursor-pointer group ml-auto">
-            <ShareIcon class="icon icon-primary icon-small" />
-            <span class="text-grey-400 group-hover:text-grey-500">Share</span>
-          </div>
+          <!-- tweets the url of this grant -->
+
+          <a
+            target="_blank"
+            rel="noreferrer noopener"
+            :href="
+              'https://twitter.com/intent/tweet' +
+              '?text=' +
+              encodeURIComponent('Checkout ' + grantMetadata?.name + ' at Gitcoins Decentral Grants App!') +
+              '&url=' +
+              encodeURIComponent('https://grants.gtcdao.net/#') +
+              $route.path
+            "
+            class="flex items-center gap-x-2 cursor-pointer group ml-auto"
+          >
+            <TwitterIcon class="icon icon-primary icon-small" />
+            <span class="text-grey-400 group-hover:text-grey-500">Tweet</span>
+          </a>
+
           <!--edit for owner-->
           <div v-if="isOwner" @click="enableEdit()" class="flex items-center gap-x-2 cursor-pointer group">
             <EditIcon class="icon icon-primary icon-small" />
@@ -284,7 +298,7 @@ import TransactionStatus from 'src/components/TransactionStatus.vue';
 import LoadingSpinner from 'src/components/LoadingSpinner.vue';
 import { CLR, fetch, InitArgs, linear } from '@dgrants/dcurve';
 // --- Icons ---
-import { ArrowToprightIcon as ShareIcon } from '@fusion-icons/vue/interface';
+import { TwitterIcon as TwitterIcon } from '@fusion-icons/vue/interface';
 import { Edit3Icon as EditIcon } from '@fusion-icons/vue/interface';
 
 function useGrantDetail() {
@@ -670,7 +684,7 @@ export default defineComponent({
     GrantDetailsRow,
     InputRow,
     SectionHeader,
-    ShareIcon,
+    TwitterIcon,
     TransactionStatus,
     LoadingSpinner,
   },

--- a/app/src/views/GrantRound.vue
+++ b/app/src/views/GrantRound.vue
@@ -80,9 +80,11 @@
           target="_blank"
           rel="noreferrer noopener"
           :href="
-            'https://twitter.com/intent/tweet?text=' +
-            grantRoundMetadata?.name +
-            '&url=https://grants.gtcdao.net' +
+            'https://twitter.com/intent/tweet' +
+            '?text=' +
+            encodeURIComponent('Checkout ' + grantRoundMetadata?.name + ' at Gitcoins Decentral Grants App!') +
+            '&url=' +
+            encodeURIComponent('https://grants.gtcdao.net/#') +
             $route.path
           "
           class="flex items-center gap-x-2 cursor-pointer group ml-auto"
@@ -90,6 +92,7 @@
           <TwitterIcon class="icon icon-primary icon-small" />
           <span class="text-grey-400 group-hover:text-grey-500">Tweet</span>
         </a>
+
         <!-- Add funds to Grant Round -->
         <div @click="showAddFunds()" class="flex items-center gap-x-2 cursor-pointer group">
           <DonateIcon class="icon icon-primary icon-small" />

--- a/app/src/views/GrantRound.vue
+++ b/app/src/views/GrantRound.vue
@@ -189,7 +189,7 @@ import {
 import { GrantRound, GrantRoundMetadata, Breadcrumb } from '@dgrants/types';
 
 // --- Icons ---
-import { TwitterIcon as TwitterIcon } from '@fusion-icons/vue/interface';
+import { TwitterIcon } from '@fusion-icons/vue/interface';
 import { DonateIcon } from '@fusion-icons/vue/interface';
 
 // --- Contract ---


### PR DESCRIPTION
### inputs + nonnative select quick fix

<img width="370" alt="Bildschirmfoto 2021-09-15 um 13 15 52" src="https://user-images.githubusercontent.com/569641/133439546-88884356-b5d4-4bd6-9485-56cb14ff2383.png">

- temporary fix for height issues when combining native inputs with non-native selects
( top = after .  bottom = before )
Closes #239


### tweets for grant detail view, round detail view, cart view

<img width="975" alt="Bildschirmfoto 2021-09-15 um 15 09 46" src="https://user-images.githubusercontent.com/569641/133439715-c27cd818-e9fe-471d-8845-dfb0426e8ec7.png">

- add working rudimentary tweet buttons  that share
"Checkout {round or grant} at Gitcoins Decentral Grants App!"
+ a generated encoded Link to https://grants.gtcdao.net + route to a specific grant / round

Closes #200


### notification styling

https://user-images.githubusercontent.com/569641/133439774-5e369c3c-b8ef-45e3-ac36-fc4c27a7319d.mov

- styling as good as i can this bn-notify addon,
whats not very stylable ( eg i can not set a better width for a notification )

came up with the idea this notifications show "behind the scenes" as a mini terminal,
as this shows so cryptic stuff all the time right now ^^ + i think our audience 
is technical versatile and love terminals too.

ps : that plugin is hard to style - can not even change width because that transitions to the right on hide i guess



