### PR TITLE
InputRow / Base Inputs ui fix

### DIFF
--- a/app/src/components/BaseInput.vue
+++ b/app/src/components/BaseInput.vue
@@ -14,10 +14,10 @@
       :placeholder="placeholder"
       :min="type === 'number' && min ? min : undefined"
     />
-  </div>
 
-  <div v-if="!isValid">
-    <div class="bg-pink p-4 text-white" :id="`${id}-error`">{{ errorMsg }}</div>
+    <div v-if="!isValid">
+      <div class="bg-pink p-4 text-white" :id="`${id}-error`">{{ errorMsg }}</div>
+    </div>
   </div>
 </template>
 

--- a/app/src/components/BaseTextarea.vue
+++ b/app/src/components/BaseTextarea.vue
@@ -12,10 +12,10 @@
       :disabled="disabled"
       :placeholder="placeholder"
     />
-  </div>
 
-  <div v-if="!isValid">
-    <div class="bg-pink p-4 text-white" :id="`${id}-error`">{{ errorMsg }}</div>
+    <div v-if="!isValid">
+      <div class="bg-pink p-4 text-white" :id="`${id}-error`">{{ errorMsg }}</div>
+    </div>
   </div>
 </template>
 

--- a/app/src/components/InputRow.vue
+++ b/app/src/components/InputRow.vue
@@ -9,12 +9,12 @@
 
         <!-- input + optional description -->
         <div class="col-span-4 md:col-span-3">
-          <div class="flex items-center gap-x-8">
+          <div class="flex items-center">
             <slot name="input"></slot>
 
             <!-- deletable -->
             <div v-if="deleteable" class="col-span-3 justify-self-end">
-              <XIcon class="icon icon-primary icon-small cursor-pointer" />
+              <XIcon class="icon icon-primary icon-small cursor-pointer ml-4" />
             </div>
           </div>
           <div v-if="text" class="mt-2">{{ text }}</div>


### PR DESCRIPTION
### Bug
There is currently a little bug, that error messages appear right

<img width="1273" alt="Bildschirmfoto 2021-09-16 um 18 26 25" src="https://user-images.githubusercontent.com/569641/133657002-7bd0faac-4892-4226-aebe-0733c6e77323.png">


### Fix
I fixed this , so error messages appear under the input.

<img width="936" alt="Bildschirmfoto 2021-09-16 um 19 28 37" src="https://user-images.githubusercontent.com/569641/133657934-6183a43a-889c-488c-85db-2453ad3ad48c.png">


### Sidenote
- input v-slots can handle multiple inputs in same line ( e.g. for text-input + select-input combinations )
- a row can be deletable ( not needed now, this was planed to use for some features that we maybe have later
( e.g. add team members to your grant ) 

<img width="938" alt="Bildschirmfoto 2021-09-16 um 19 17 21" src="https://user-images.githubusercontent.com/569641/133657280-47da179f-24f4-4069-9bfd-77db293de6e8.png">



