### PR TITLE
improved UI BaseFilterNav

### DIFF
--- a/app/src/components/BaseFilterNav.vue
+++ b/app/src/components/BaseFilterNav.vue
@@ -1,27 +1,29 @@
 <template>
-  <div class="px-4 md:px-12 py-8 border-b border-grey-100">
-    <div class="block md:flex gap-x-8">
-      <div class="flex flex-wrap content-center gap-x-8">
-        <div v-for="(item, index) in items" :key="item.label">
-          <div class="cursor-pointer uppercase font-medium group" @click="item?.action">
+  <!-- wrapper for border bottom + padding -->
+  <section>
+    <!-- wrapper for left nav items + right optional button -->
+    <div class="flex flex-col gap-y-4 md:flex-row gap-x-8">
+      <!-- nav items wrapper -->
+      <div class="flex flex-wrap whitespace-nowrap content-center gap-x-8 gap-y-4">
+        <!-- nav item loop -->
+        <ul v-for="(item, index) in items" :key="item.label">
+          <!-- nav item -->
+          <li @click="item?.action">
+            <!-- if item have a menu show label in grey with a : at end -->
             <span v-if="item.menu" class="text-grey-400">{{ item.label + ':' }}</span>
+
+            <!-- else just show the label-->
             <span v-else :class="active == index ? 'border-b pb-1' : 'text-grey-400'">{{ item.label }}</span>
+
+            <!-- if item have a counter -->
             <span v-if="item.counter" class="ml-2 text-grey-400">({{ item.counter }})</span>
-            <span v-else-if="item.tag" class="ml-2">{{ item.tag }}</span>
+
+            <!-- if item have a item tag -->
+            <span v-if="item.tag" class="ml-2">{{ item.tag }}</span>
+
+            <!-- if item have a menu render a menu for it -->
             <div v-if="item.menu" class="absolute hidden group-hover:block text-left z-10">
-              <div
-                class="
-                  border border-grey-400
-                  p-6
-                  pr-10
-                  bg-white
-                  text-grey-400
-                  flex flex-col
-                  gap-y-2
-                  uppercase
-                  font-medium
-                "
-              >
+              <div class="menu">
                 <div
                   v-for="(menuItem, menuIndex) in item.menu"
                   :key="menuItem.label"
@@ -38,15 +40,16 @@
                 </div>
               </div>
             </div>
-          </div>
-        </div>
+          </li>
+        </ul>
       </div>
+
       <!--optional button -->
       <div v-if="button" class="mt-4 md:mt-0 ml-auto">
         <button class="btn" @click="button?.action">{{ button.label }}</button>
       </div>
     </div>
-  </div>
+  </section>
 </template>
 
 <script lang="ts">
@@ -64,3 +67,17 @@ export default defineComponent({
   },
 });
 </script>
+
+<style scoped>
+section {
+  @apply px-4 md:px-12 py-8 border-b border-grey-100;
+}
+
+li {
+  @apply cursor-pointer uppercase font-medium group;
+}
+
+.menu {
+  @apply border border-grey-400 p-6 pr-10 bg-white text-grey-400 flex flex-col gap-y-2 uppercase font-medium;
+}
+</style>


### PR DESCRIPTION
old design for basefilternav was semi-optimal for small screens + a bit hard to read code,
so i worked a bit on this one to have a pragmatic lightweight good behaviour on all screensizes.

https://user-images.githubusercontent.com/569641/134041116-17d3a76f-3b16-4a1c-a6fc-39aedc09bb9f.mov

- enhanced design for small resolutions
- better scalable on more items ( e.g. when its more than 5 items )
- bit better code with less div in div in div by using some semantic tags
- outsource some css to <style> for better readability
- some more comments for better readability

( doing this cleanups also to be able to see where we have css-patterns that appear over and over to add some later on into the index.css  as i did with base-grid ...  ) 
