### PR TITLE
fix grant detail UI, when its multiple rounds same time

### DIFF
--- a/app/src/components/GrantDetailsRow.vue
+++ b/app/src/components/GrantDetailsRow.vue
@@ -35,35 +35,21 @@
 
       <!-- rounds a grant is in -->
       <article class="mt-8">
-        <div v-for="(round, index) in roundDetails" :key="index" class="mt-4">
+        <div v-for="(round, index) in roundDetails" :key="index" class="mt-2">
           <!--round-->
           <div>
-            <span class="text-grey-400 mr-4">Round:</span>
-            <span class="mr-2">{{ round.name }}</span>
+            <span class="text-grey-400 mr-4">Matching:</span>
+            <span>{{ round.matching }} {{ round.matchingToken.symbol }}</span>
+            <span>, {{ round.name }}</span>
           </div>
 
           <!--matching-->
           <div>
-            <span class="text-grey-400 mr-4">Matching:</span>
-            <span>{{ round.matching }} {{ round.matchingToken.symbol }}</span>
-          </div>
-
-          <!--prediction 10 -->
-          <div>
-            <span class="text-grey-400 mr-4"
-              >10 {{ roundDetails[0] ? roundDetails[0].donationToken.symbol : '' }} Contribution</span
-            >
-            <span class="mr-4">≈</span>
-            <span>{{ round.prediction10 }} {{ round.matchingToken.symbol }}</span>
-          </div>
-
-          <!--prediction 100 -->
-          <div>
-            <span class="text-grey-400 mr-4"
-              >100 {{ roundDetails[0] ? roundDetails[0].donationToken.symbol : '' }} Contribution</span
-            >
-            <span class="mr-4">≈</span>
-            <span>{{ round.prediction100 }} {{ round.matchingToken.symbol }}</span>
+            <span class="text-grey-300 italic">
+              10 {{ roundDetails[0] ? roundDetails[0].donationToken.symbol : '' }} ≈ {{ round.prediction10 }}
+              {{ round.matchingToken.symbol }}, 100 {{ roundDetails[0] ? roundDetails[0].donationToken.symbol : '' }} ≈
+              {{ round.prediction100 }} {{ round.matchingToken.symbol }}
+            </span>
           </div>
         </div>
       </article>

--- a/app/src/components/GrantDetailsRow.vue
+++ b/app/src/components/GrantDetailsRow.vue
@@ -1,70 +1,74 @@
 <template>
-  <div class="border-b border-grey-100 grid grid-cols-1 md:grid-cols-2 gap-x-14">
+  <!-- grid sm:1col md:2col -->
+  <section class="border-b border-grey-100 grid grid-cols-1 md:grid-cols-2">
     <!--grid:left (img)-->
-    <div>
+    <figure>
       <img class="shadow-light object-cover h-full" :src="logoURI || '/placeholder_grant.svg'" />
-    </div>
+    </figure>
 
     <!--grid:right (txt)-->
-    <div class="my-6 px-8 md:px-0">
-      <!-- raised -->
-      <div><span class="text-grey-400 mr-4">Raised:</span>{{ totalRaised }}</div>
+    <div class="my-6 px-4 md:px-8">
+      <!-- raised amount, contract, donate button -->
+      <article>
+        <!-- raised -->
+        <div><span class="text-grey-400 mr-4">Raised:</span>{{ totalRaised }}</div>
 
-      <!--contract-->
-      <div>
-        <span class="text-grey-400 mr-4">Contract:</span>
-        <a class="link" :href="getEtherscanUrl(payoutAddress, 'address')" target="_blank" rel="noopener noreferrer">{{
-          formatAddress(payoutAddress)
-        }}</a>
-      </div>
-
-      <!--round-->
-      <div>
-        <span class="text-grey-400 mr-4">In Round:</span>
-        <span v-for="(round, index) in roundDetails" :key="index">
-          {{ round.name }}<span v-if="index + 1 < roundDetails.length">, </span>
-        </span>
-      </div>
-
-      <!--matching-->
-      <div>
-        <span class="text-grey-400 mr-4">Matching:</span>
-        <span v-for="(round, index) in roundDetails" :key="index">
-          {{ round.matching }} {{ round.matchingToken.symbol }}
-          <span v-if="index + 1 < roundDetails.length">, </span>
-        </span>
-      </div>
-
-      <!-- button -->
-      <div class="mt-8">
-        <button v-if="isInCart(grant?.id)" @click="removeFromCart(grant?.id)" class="btn in-cart btn-primary">
-          <CartIcon class="icon-small" />Remove
-        </button>
-
-        <button v-else @click="addToCart(grant?.id)" class="btn btn-primary"><CartIcon class="icon-small" />Add</button>
-      </div>
-
-      <!-- matching example -->
-      <div class="mt-4">
+        <!--contract-->
         <div>
-          10 {{ roundDetails[0] ? roundDetails[0].donationToken.symbol : '' }} ≈
-          <span v-for="(round, index) in roundDetails" :key="index">
-            {{ round.prediction10 }} {{ round.matchingToken.symbol
-            }}<span v-if="index + 1 < roundDetails.length">, </span>
-          </span>
-          Matching
+          <span class="text-grey-400 mr-4">Contract:</span>
+          <a class="link" :href="getEtherscanUrl(payoutAddress, 'address')" target="_blank" rel="noopener noreferrer">{{
+            formatAddress(payoutAddress)
+          }}</a>
         </div>
-        <div>
-          100 {{ roundDetails[0] ? roundDetails[0].donationToken.symbol : '' }} ≈
-          <span v-for="(round, index) in roundDetails" :key="index">
-            {{ round.prediction100 }} {{ round.matchingToken.symbol
-            }}<span v-if="index + 1 < roundDetails.length">, </span>
-          </span>
-          Matching
+
+        <!-- button -->
+        <div class="mt-8">
+          <button v-if="isInCart(grant?.id)" @click="removeFromCart(grant?.id)" class="btn in-cart btn-primary">
+            <CartIcon class="icon-small" />Remove
+          </button>
+
+          <button v-else @click="addToCart(grant?.id)" class="btn btn-primary">
+            <CartIcon class="icon-small" />Add
+          </button>
         </div>
-      </div>
+      </article>
+
+      <!-- rounds a grant is in -->
+      <article class="mt-8">
+        <div v-for="(round, index) in roundDetails" :key="index" class="mt-4">
+          <!--round-->
+          <div>
+            <span class="text-grey-400 mr-4">Round:</span>
+            <span class="mr-2">{{ round.name }}</span>
+          </div>
+
+          <!--matching-->
+          <div>
+            <span class="text-grey-400 mr-4">Matching:</span>
+            <span>{{ round.matching }} {{ round.matchingToken.symbol }}</span>
+          </div>
+
+          <!--prediction 10 -->
+          <div>
+            <span class="text-grey-400 mr-4"
+              >10 {{ roundDetails[0] ? roundDetails[0].donationToken.symbol : '' }} Contribution</span
+            >
+            <span class="mr-4">≈</span>
+            <span>{{ round.prediction10 }} {{ round.matchingToken.symbol }}</span>
+          </div>
+
+          <!--prediction 100 -->
+          <div>
+            <span class="text-grey-400 mr-4"
+              >100 {{ roundDetails[0] ? roundDetails[0].donationToken.symbol : '' }} Contribution</span
+            >
+            <span class="mr-4">≈</span>
+            <span>{{ round.prediction100 }} {{ round.matchingToken.symbol }}</span>
+          </div>
+        </div>
+      </article>
     </div>
-  </div>
+  </section>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
### problem

<img width="537" alt="Bildschirmfoto 2021-09-21 um 11 22 56" src="https://user-images.githubusercontent.com/569641/134160035-eb0a81cd-de01-4795-a8e4-f0acf2250af2.png">

when a grant is in active multiple rounds, it's a bit confusing for a user to see, what round made a certain matching amount, and how much a potential donation would est.  add in matching based on a specific round - as there is no context between predicted amounts, matchings and round names.



### solution 

<img width="532" alt="Bildschirmfoto 2021-09-21 um 13 45 34" src="https://user-images.githubusercontent.com/569641/134164870-30666def-eee1-487c-8222-1dfa99de01e7.png">

- show each round a grant is in  with all the context ( matching, round-name, 10prediction, 100prediction)
- combine  Matching + Round in a single Line
- differentiate how predictions look ( black = current matching,  grey italic = vague prediction )

