### PR TITLE
RPC URL change + big number fix + cart UX improvements

### DIFF
--- a/app/src/utils/chains.ts
+++ b/app/src/utils/chains.ts
@@ -167,7 +167,7 @@ const ALL_CHAIN_INFO: ChainInfo = {
     grantRoundManager: '0x3692d6dE91E7Efd98d761fffe4d1541dAEF6030c',
     grantRoundManagerAbi: GRANT_ROUND_MANAGER_UNI_V2_ABI,
     multicall: '0xd3BB9902C9ae1ECbDB9cCAdbD009F827699185Cb',
-    rpcUrl: `https://polygon-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}`,
+    rpcUrl: 'https://polygon-rpc.com/',
     startBlock: 19437770,
   },
   [SupportedChainId.RINKEBY]: {

--- a/app/src/views/Cart.vue
+++ b/app/src/views/Cart.vue
@@ -155,6 +155,7 @@
       <div class="mt-12 mb-12">
         <div class="flex gap-x-4 justify-end">
           <button
+            v-if="cartStatus === ''"
             @click="executeCheckout"
             class="btn"
             :class="{ disabled: !isCorrectNetwork }"
@@ -162,6 +163,13 @@
           >
             checkout
           </button>
+          <div v-else class="flex gap-x-4 justify-end">
+            <div>
+              <div class="text-sm text-right">Transaction</div>
+              <div>{{ cartStatus }}</div>
+            </div>
+            <button class="btn disabled float-right" disabled><Spinner1Icon /></button>
+          </div>
         </div>
       </div>
     </div>
@@ -185,7 +193,7 @@
 <script lang="ts">
 // --- External Imports ---
 import { computed, defineComponent, ref, watch } from 'vue';
-import { TwitterIcon, CloseIcon } from '@fusion-icons/vue/interface';
+import { TwitterIcon, CloseIcon, Spinner1Icon } from '@fusion-icons/vue/interface';
 // --- Component Imports ---
 import BaseHeader from 'src/components/BaseHeader.vue';
 import BaseInput from 'src/components/BaseInput.vue';
@@ -204,6 +212,7 @@ function useCart() {
   const { grantMetadata: meta } = useDataStore();
   const {
     cart,
+    cartStatus,
     cartSummary,
     cartSummaryString,
     checkout,
@@ -275,6 +284,7 @@ function useCart() {
 
   return {
     cart,
+    cartStatus,
     cartSummaryString,
     clearCart,
     clrPredictions,
@@ -302,10 +312,11 @@ export default defineComponent({
     BaseHeader,
     BaseInput,
     BaseSelect,
-    TransactionStatus,
-    TwitterIcon,
-    CloseIcon,
     LoadingSpinner,
+    TransactionStatus,
+    CloseIcon,
+    Spinner1Icon,
+    TwitterIcon,
   },
   setup() {
     const NOT_IMPLEMENTED = (msg: string) => window.alert(`NOT IMPLEMENTED: ${msg}`);


### PR DESCRIPTION
Closes #234, closes #291, closes #293

Changes:
- Cart now shows approval transaction info when checking out (#234). The loading spinner is currently static and does not rotate, as @scco said he can add the rotation in / provide a snippet
- Changes the RPC URL used by Polygon, that way when users add Polygon to MetaMask they aren't using our API key (#292)
- For numbers larger than 1e21, JS formats the number as 1e+21 instead of 1000...000, which was causing the crash described in #291. This crash was because the call to `commify` failed since it doesn't support scientific notation. In those cases, we now catch the error and convert the number to a formatted string using `.toLocaleString()`. In reality, we don't want users checking out with numbers above `Number.MAX_SAFE_INTEGER` (2^53-1) anyway due to precision loss, and in reality this will not happen because no one owns that many tokens. So the fix implemented is mainly a UX thing to avoid the app crashing, and should have no practical impact 