### PR TITLE
wallet modal style update

### DIFF
--- a/app/src/index.css
+++ b/app/src/index.css
@@ -19,6 +19,12 @@
     scroll-behavior: smooth;
   }
 
+  h1 {
+    @apply text-headline;
+  }
+
+  /********* NOTIFICATION STYLES */
+
   .bn-notify-custom {
     margin-left: 0px;
   }
@@ -59,9 +65,7 @@
     display: none;
   }
 
-  h1 {
-    @apply text-headline;
-  }
+  /********* INPUT STYLES  */
 
   [type="text"],
   [type="email"],
@@ -82,6 +86,34 @@
     @apply hover:border-grey-500;
     @apply focus:outline-none focus:border-grey-500 focus:ring-0;
     font-size: 100%;
+  }
+
+  /********* WALLET MODAL STYLES */
+
+  /*The full page modal container*/
+  .bn-onboard-custom.bn-onboard-modal {
+    font-family: Source Code Pro, monospace;
+    @apply bg-white bg-opacity-90 font-normal;
+  }
+
+  /*The container for the modal content*/
+  .bn-onboard-custom.bn-onboard-modal-content {
+    @apply border-2 border-grey-500 rounded-none px-6 py-6;
+  }
+
+  /*The header of the modal*/
+  .bn-onboard-custom.bn-onboard-modal-content-header {
+    @apply mb-0;
+  }
+
+  /*The heading within the header*/
+  .bn-onboard-custom.bn-onboard-modal-content-header-heading {
+    @apply font-medium m-0;
+    font-size: 100%;
+  }
+
+  .bn-onboard-custom.bn-onboard-modal-content-header-icon {
+    display: none;
   }
 }
 


### PR DESCRIPTION
closes #288

the style-ability for the Onboard Lib is sadly not good enough - same for their outdated documentation of css classes to throw styles on - what in most cases not works as expected.

- there are hardcoded styles i can not modify
- some svelte compiled extra classes i can not target at all as they change names on each build
- theres no way to adjust general behaviours / templates / components to play with grids, other dom structures that would me allow to add custom icons . 

i disagree on @mds1 that users would be confused on other icons, and think that this love to detail would give a more appreciated experience. its no usability issue but a loss for a high quality experience.

so i just could tweak some basics, but would love to revisit this topic when we have time for this level of detail.

<img width="468" alt="Bildschirmfoto 2021-09-29 um 15 22 06" src="https://user-images.githubusercontent.com/569641/135277997-e2950d44-93a4-4273-9e7b-0c4e711289f7.png">


see here how these icons would look in a modal i did for web3modal

https://schumanncombo.com/web3modal/