### PR TITLE
bug: (dCurve) Groups and sums contributions for linear calc

### DIFF
--- a/dcurve/src/internal/utils.ts
+++ b/dcurve/src/internal/utils.ts
@@ -65,7 +65,6 @@ export function lerp(x_lower: number, x_upper: number, y_lower: number, y_upper:
  * @param {Number} amount Human readable amount denominated in the GrantRounds matchingToken
  */
 export function getPredictedMatchingForAmount(clr_predictions: GrantPrediction, amount: number) {
-
   if (amount < 0) {
     return 0;
   }

--- a/dcurve/src/types.ts
+++ b/dcurve/src/types.ts
@@ -39,7 +39,7 @@ export type ContributionsByGrantId = {
   [grantId: string]: {
     grantId: string;
     grantAddress: string;
-    contributions: Contribution[];
+    contributions: Record<string, Contribution>;
   };
 };
 


### PR DESCRIPTION
This PR will fix the linear calc to group and sum contributions by grantId and contributor.

--

Fixes: #302