### PR TITLE
feat: add walletconnect support

### DIFF
--- a/app/src/store/wallet.ts
+++ b/app/src/store/wallet.ts
@@ -23,7 +23,7 @@
 import { computed, ref, markRaw } from 'vue';
 import useDataStore from 'src/store/data';
 import useSettingsStore from 'src/store/settings';
-import { CHAIN_INFO, DGRANTS_CHAIN_ID, GRANT_REGISTRY_ADDRESS, GRANT_ROUND_MANAGER_ADDRESS, MULTICALL_ADDRESS, RPC_URL, SupportedChainId } from 'src/utils/chains'; // prettier-ignore
+import { ALL_CHAIN_INFO, CHAIN_INFO, DGRANTS_CHAIN_ID, GRANT_REGISTRY_ADDRESS, GRANT_ROUND_MANAGER_ADDRESS, MULTICALL_ADDRESS, RPC_URL, SupportedChainId } from 'src/utils/chains'; // prettier-ignore
 import { BigNumber, Contract, hexStripZeros, JsonRpcProvider, JsonRpcSigner, Network, Web3Provider } from 'src/utils/ethers'; // prettier-ignore
 import { formatAddress } from 'src/utils/utils';
 import Onboard from 'bnc-onboard';
@@ -54,8 +54,14 @@ function resetState() {
 }
 
 // Settings
+const rpcUrlsByChain: Record<string, string> = {};
+Object.entries(ALL_CHAIN_INFO).forEach(([chainId, chainData]) => (rpcUrlsByChain[String(chainId)] = chainData.rpcUrl));
+
 const walletChecks = [{ checkName: 'connect' }];
-const wallets = [{ walletName: 'metamask', preferred: true }]; // TODO determine set of wallets to support, and make sure rpcUrls are reactive based on network
+const wallets = [
+  { walletName: 'metamask', preferred: true },
+  { walletName: 'walletConnect', rpc: rpcUrlsByChain, preferred: true },
+];
 
 export default function useWalletStore() {
   // ------------------------------------------------ Wallet Connection ------------------------------------------------
@@ -166,6 +172,7 @@ export default function useWalletStore() {
 
     // Get ENS name if user is connected to mainnet
     const chainId = _provider.network.chainId; // must be done after the .getNetwork() call
+    console.log('connected on chainId: ', chainId);
     const _userEns = chainId === 1 ? await _provider.lookupAddress(_userAddress) : null;
 
     // Now we save the user's info to the store. We don't do this earlier because the UI is reactive based on these

--- a/app/src/utils/alerts.ts
+++ b/app/src/utils/alerts.ts
@@ -12,6 +12,7 @@ const messagesToIgnore = [
   'walletSelect must be called before walletCheck', // user decided not to connect wallet
   'unknown account #0', // happens when we try to connect to a locked wallet
   'TypeError: _context.t2 is not a constructor', // https://github.com/dcgtc/dgrants/issues/26
+  'PollingBlockTracker - encountered an error while attempting to update latest block', // occurs if you use walletconnect + Argent and connect with a chainId different than DGRANTS_CHAIN_ID
 ];
 
 /**

--- a/app/src/utils/chains.ts
+++ b/app/src/utils/chains.ts
@@ -125,7 +125,7 @@ const ALL_SUPPORTED_TOKENS_MAPPING: { readonly [chainId: number]: Record<string,
 })();
 
 // --- Data for all supported chains ---
-const ALL_CHAIN_INFO: ChainInfo = {
+export const ALL_CHAIN_INFO: ChainInfo = {
   [SupportedChainId.HARDHAT]: {
     explorer: 'https://etherscan.io',
     label: 'Hardhat',


### PR DESCRIPTION
Closes #275

To test, use connect with WalletConnect (WC) on Rinkeby and create a grant and/or checkout your cart. My current attempts at WC testing:
- Rainbow wallet's Rinkeby connection didn't seem to be working (the chainId is logged as 1)
- MetaMask connects to chainId but throws `TypeError: Failed to fetch` when I try to send a transaction. (I tried MetaMask + WC + Rinkeby on Uniswap and it throws with `Could not deposit invalid opcode: opcode 0xfe not defined`, so I don't think the problem is on our side)

 Any recommendations on other WC wallets that support Rinkeby are welcome!