### PR TITLE
image-aspect-ratio

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -19,6 +19,7 @@
     "@dgrants/types": "^0.0.1",
     "@fusion-icons/vue": "^0.0.0",
     "@headlessui/vue": "^1.2.0",
+    "@tailwindcss/aspect-ratio": "^0.2.1",
     "@tailwindcss/forms": "^0.3.3",
     "@uniswap/token-lists": "^1.0.0-beta.25",
     "@uniswap/v3-sdk": "^3.3.2",

--- a/app/src/components/GrantCard.vue
+++ b/app/src/components/GrantCard.vue
@@ -5,9 +5,14 @@
     class="group cursor-pointer"
     @click="pushRoute({ name: 'dgrants-id', params: { id: BigNumber.from(id).toString() } })"
   >
-    <!--img-->
+    <!--wrapper to position img and cart button-->
     <div class="relative">
-      <img class="shadow-light group-hover:opacity-90" :src="imgurl" />
+      <!--img-->
+      <div class="aspect-w-16 aspect-h-9 shadow-light">
+        <img class="w-full h-full object-center object-cover group-hover:opacity-90" :src="imgurl" />
+      </div>
+
+      <!--cart button-->
       <div class="absolute bottom-0 right-0">
         <button
           class="btn opacity-0 group-hover:opacity-100"
@@ -18,6 +23,7 @@
         </button>
       </div>
     </div>
+
     <figcaption class="mt-4">
       <div class="truncate">{{ name }}</div>
       <div>

--- a/app/src/components/GrantDetailsRow.vue
+++ b/app/src/components/GrantDetailsRow.vue
@@ -2,8 +2,8 @@
   <!-- grid sm:1col md:2col -->
   <section class="border-b border-grey-100 grid grid-cols-1 md:grid-cols-2">
     <!--grid:left (img)-->
-    <figure>
-      <img class="shadow-light object-cover h-full" :src="logoURI || '/placeholder_grant.svg'" />
+    <figure class="aspect-w-16 aspect-h-9 shadow-light">
+      <img class="w-full h-full object-center object-cover" :src="logoURI || '/placeholder_grant.svg'" />
     </figure>
 
     <!--grid:right (txt)-->

--- a/app/src/components/GrantRoundCard.vue
+++ b/app/src/components/GrantRoundCard.vue
@@ -2,8 +2,8 @@
 <template>
   <figure class="group cursor-pointer" @click="pushRoute({ name: 'dgrants-round', params: { address: address } })">
     <!--img-->
-    <div>
-      <img class="shadow-light group-hover:opacity-90" :src="imgurl" />
+    <div class="aspect-w-16 aspect-h-9 shadow-light">
+      <img class="w-full h-full object-center object-cover group-hover:opacity-90" :src="imgurl" />
     </div>
 
     <figcaption class="mt-4">

--- a/app/src/components/GrantRoundDetailsRow.vue
+++ b/app/src/components/GrantRoundDetailsRow.vue
@@ -1,9 +1,12 @@
 <template>
   <div class="border-b border-grey-100 grid grid-cols-1 md:grid-cols-2 gap-x-14">
     <!--grid:left (img)-->
-    <div>
-      <img class="shadow-light object-cover h-full" :src="grantRoundMetadata?.logoURI || '/placeholder_grant.svg'" />
-    </div>
+    <figure class="aspect-w-16 aspect-h-9 shadow-light">
+      <img
+        class="w-full h-full object-center object-cover"
+        :src="grantRoundMetadata?.logoURI || '/placeholder_grant.svg'"
+      />
+    </figure>
 
     <!--grid:right (txt)-->
     <div class="my-6 px-8 md:px-0">

--- a/app/src/store/wallet.ts
+++ b/app/src/store/wallet.ts
@@ -172,7 +172,6 @@ export default function useWalletStore() {
 
     // Get ENS name if user is connected to mainnet
     const chainId = _provider.network.chainId; // must be done after the .getNetwork() call
-    console.log('connected on chainId: ', chainId);
     const _userEns = chainId === 1 ? await _provider.lookupAddress(_userAddress) : null;
 
     // Now we save the user's info to the store. We don't do this earlier because the UI is reactive based on these

--- a/app/src/views/Cart.vue
+++ b/app/src/views/Cart.vue
@@ -60,8 +60,11 @@
             <div class="grid grid-cols-4 items-center gap-x-8 gap-y-4">
               <!-- image -->
               <div class="col-span-4 lg:col-span-1">
-                <figure class="max-w-lg">
-                  <img class="shadow-light" :src="grantMetadata[item.metaPtr]?.logoURI || '/placeholder_grant.svg'" />
+                <figure class="aspect-w-16 aspect-h-9 shadow-light">
+                  <img
+                    class="w-full h-full object-center object-cover group-hover:opacity-90"
+                    :src="grantMetadata[item.metaPtr]?.logoURI || '/placeholder_grant.svg'"
+                  />
                 </figure>
               </div>
               <!-- text -->

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -61,5 +61,5 @@ module.exports = {
       stroke: ['group-hover', 'hover'],
     },
   },
-  plugins: [require('@tailwindcss/forms')],
+  plugins: [require('@tailwindcss/forms'), require('@tailwindcss/aspect-ratio')],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2436,6 +2436,11 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@tailwindcss/aspect-ratio@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/aspect-ratio/-/aspect-ratio-0.2.1.tgz#a7ce776688b8218d9559a6918f0bccc58f0f16dd"
+  integrity sha512-aDFi80aHQ3JM3symJ5iKU70lm151ugIGFCI0yRZGpyjgQSDS+Fbe93QwypC1tCEllQE8p0S7TUu20ih1b9IKLA==
+
 "@tailwindcss/forms@^0.3.3":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@tailwindcss/forms/-/forms-0.3.3.tgz#a29d22668804f3dae293dcadbef1aa6315c45b64"
@@ -5267,7 +5272,7 @@ braces@^3.0.1, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-brorand@^1.0.1, brorand@^1.1.0, "brorand@https://github.com/buu700/brorand#1b8c372b3c78bd5287728c1d5b4bf9cb8b708196":
+brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
   resolved "https://github.com/buu700/brorand#1b8c372b3c78bd5287728c1d5b4bf9cb8b708196"
 


### PR DESCRIPTION
as we discussed in 

https://github.com/dcgtc/dgrants/discussions/301

about image crop - i enabled the UI to work with ALL image dimensions by wrapping images into a container what is set to a specific aspect ratio, that masks the image nicely into the desired format . 

so we can bring images to any desired aspect ratio like this

```
<figure class="aspect-w-16 aspect-h-9">
   <img class="w-full h-full object-center object-cover" src="" />
</figure>
```

as the native css support for `aspect-ratio` is still not the best ( missing edge/IE ) i decided to go with a tailwind plugin 
https://github.com/tailwindlabs/tailwindcss-aspect-ratio
that works niceley - via the old "padding-bottom-trick" 

you need to rerun `yarn install` before you can see it working. 

if you want to try out how this truly looks with other dimension images you can easy replace the image source of a card or detail page with a rectangle image via inspector of your browser `src="http://placekitten.com/1000/1000"`  or just create a new grant :)



