### PR TITLE
BaseFilterNav optional prop : title  closes #329

### DIFF
--- a/app/src/components/BaseFilterNav.vue
+++ b/app/src/components/BaseFilterNav.vue
@@ -5,6 +5,9 @@
     <div class="flex flex-col gap-y-4 md:flex-row gap-x-8">
       <!-- nav items wrapper -->
       <div class="flex flex-wrap whitespace-nowrap content-center gap-x-8 gap-y-4">
+        <!--optional title -->
+        <div v-if="title" class="uppercase font-medium">{{ title }}</div>
+
         <!-- nav item loop -->
         <ul v-for="(item, index) in items" :key="item.label">
           <!-- nav item -->
@@ -63,6 +66,7 @@ export default defineComponent({
   name: 'BaseFilterNav',
   components: {},
   props: {
+    title: { type: String, required: false },
     items: { type: Array as PropType<FilterNavItem[]>, required: true },
     active: { type: Number, required: false, default: 0 },
     button: { type: Object as PropType<undefined | FilterNavButton>, required: false, default: undefined },

--- a/app/src/components/GrantList.vue
+++ b/app/src/components/GrantList.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- General filters -->
-  <BaseFilterNav :items="grantRegistryListNav" :button="button" title="grants:" />
+  <BaseFilterNav :items="grantRegistryListNav" :button="button" />
   <ul class="base-grid">
     <li v-for="grant in sortedGrants" :key="grant.id.toString()">
       <GrantCard


### PR DESCRIPTION
### issue
as we not 100% going with the original design it became unclear on /home
what is a round list and what is a grant list . 

### solution
was already build but got lost / wrongly used - by
adding an optional property `title` to the component `BaseFilterNav`
that conditional show the title to the front of the BaseFilterNav when there is a title property. 

###  bugfix
- the component BaseFilterNav does not need a title property for `BaseFilterNav` in `GrantList.vue` 



closes #329