### PR TITLE
fix: ensure we pass the GrantRound into getGrantRoundGrantData

### DIFF
--- a/app/src/utils/data/grantRounds.ts
+++ b/app/src/utils/data/grantRounds.ts
@@ -465,7 +465,7 @@ async function updateGrantRound(
       }
 
       // push the new grant round
-      const grantRound = (await getGrantRound(blockNumber, grantRoundAddress)) as GrantRound;
+      const grantRound = (await getGrantRound(blockNumber, grantRoundAddress)).grantRound as GrantRound;
 
       // get the clr data for the round
       const grantRoundCLRData = await getGrantRoundGrantData(


### PR DESCRIPTION
This PR ensures we're passing the `GrantRound` into `getGrantRoundGrantData`