### PR TITLE
fix: prevent trustBonus gets if there are no new addresses

### DIFF
--- a/utils/src/trustBonus.ts
+++ b/utils/src/trustBonus.ts
@@ -26,7 +26,7 @@ export const fetchTrustBonusScore = async (addresses: string[]): Promise<TrustBo
     data: [],
   };
 
-  if (addresses.length == 0) return result;
+  if (addresses.filter((v) => v).length == 0) return result;
 
   const url = `https://gitcoin.co/grants/v1/api/trust-bonus?addresses=${addresses.join(',')}`;
 


### PR DESCRIPTION
This PR filters for any new new addresses before making the fetch to prevent `[undefined]` returning a `400: Bad Request`