### PR TITLE
fix: provider change watchers

### DIFF
--- a/app/src/components/GrantCard.vue
+++ b/app/src/components/GrantCard.vue
@@ -59,7 +59,7 @@ function getTotalRaised(grantId: number) {
   const raised = `${formatNumber(
     contributions.reduce((total, contribution) => contribution?.amount + total, 0),
     2
-  )} ${grantRounds.value && grantRounds.value[0].donationToken.symbol}`;
+  )} ${grantRounds.value && grantRounds.value[0] && grantRounds.value[0].donationToken.symbol}`;
   return raised;
 }
 

--- a/app/src/store/data.ts
+++ b/app/src/store/data.ts
@@ -33,7 +33,7 @@ import { DefaultStorage, getStorageKey, setStorageKey } from 'src/utils/data/uti
 import { GRANT_ROUND_ABI, ERC20_ABI } from 'src/utils/constants';
 
 // --- Parameters required ---
-const { provider, grantRoundManager, network } = useWalletStore();
+const { provider, defaultProvider, grantRoundManager, network } = useWalletStore();
 
 // --- State ---
 // Most recent data read is saved as state
@@ -284,6 +284,9 @@ export default function useDataStore() {
    * @notice Call this method to poll now, then poll on each new block
    */
   async function startPolling() {
+    // clear old wallet connections
+    provider.value.removeAllListeners(); // provider used when wallet is connected
+    defaultProvider.value.removeAllListeners(); // provider used when no wallet is connected
     // record the network value to detect changes
     const networkValue = (await getStorageKey('network'))?.data || network.value;
     // watch the network

--- a/app/src/store/data.ts
+++ b/app/src/store/data.ts
@@ -28,12 +28,17 @@ import {
 } from '@dgrants/types';
 import { fetchMetaPtrs } from 'src/utils/data/ipfs';
 import { TokenInfo } from '@uniswap/token-lists';
-import { GRANT_REGISTRY_ADDRESS, GRANT_ROUND_MANAGER_ADDRESS, SUPPORTED_TOKENS_MAPPING } from 'src/utils/chains';
+import {
+  GRANT_REGISTRY_ADDRESS,
+  GRANT_ROUND_MANAGER_ADDRESS,
+  SUPPORTED_TOKENS_MAPPING,
+  DEFAULT_PROVIDER,
+} from 'src/utils/chains';
 import { DefaultStorage, getStorageKey, setStorageKey } from 'src/utils/data/utils';
 import { GRANT_ROUND_ABI, ERC20_ABI } from 'src/utils/constants';
 
 // --- Parameters required ---
-const { provider, defaultProvider, grantRoundManager, network } = useWalletStore();
+const { provider, grantRoundManager, network } = useWalletStore();
 
 // --- State ---
 // Most recent data read is saved as state
@@ -286,7 +291,7 @@ export default function useDataStore() {
   async function startPolling() {
     // clear old wallet connections
     provider.value.removeAllListeners(); // provider used when wallet is connected
-    defaultProvider.value.removeAllListeners(); // provider used when no wallet is connected
+    DEFAULT_PROVIDER.removeAllListeners(); // provider used when no wallet is connected
     // record the network value to detect changes
     const networkValue = (await getStorageKey('network'))?.data || network.value;
     // watch the network

--- a/app/src/store/wallet.ts
+++ b/app/src/store/wallet.ts
@@ -41,6 +41,7 @@ const defaultProvider = new JsonRpcProvider(RPC_URL);
 let onboard: OnboardAPI; // instance of Blocknative's onboard.js library
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const rawProvider = ref<any>(); // raw provider from the user's wallet, e.g. EIP-1193 provider
+const defProvider = ref<Web3Provider | JsonRpcProvider>(markRaw(defaultProvider)); // default provider
 const provider = ref<Web3Provider | JsonRpcProvider>(markRaw(defaultProvider)); // ethers provider
 const signer = ref<JsonRpcSigner>(); // ethers signer
 const userAddress = ref<string>(); // user's wallet address
@@ -253,6 +254,7 @@ export default function useWalletStore() {
     isCorrectNetwork,
     isSupportedNetwork,
     multicall,
+    defaultProvider: computed(() => defProvider.value),
     network: computed(() => network.value),
     provider: computed(() => provider.value),
     signer: computed(() => signer.value),

--- a/app/src/store/wallet.ts
+++ b/app/src/store/wallet.ts
@@ -23,7 +23,7 @@
 import { computed, ref, markRaw } from 'vue';
 import useDataStore from 'src/store/data';
 import useSettingsStore from 'src/store/settings';
-import { ALL_CHAIN_INFO, CHAIN_INFO, DGRANTS_CHAIN_ID, GRANT_REGISTRY_ADDRESS, GRANT_ROUND_MANAGER_ADDRESS, MULTICALL_ADDRESS, RPC_URL, SupportedChainId } from 'src/utils/chains'; // prettier-ignore
+import { ALL_CHAIN_INFO, CHAIN_INFO, DGRANTS_CHAIN_ID, GRANT_REGISTRY_ADDRESS, GRANT_ROUND_MANAGER_ADDRESS, MULTICALL_ADDRESS, DEFAULT_PROVIDER, SupportedChainId } from 'src/utils/chains'; // prettier-ignore
 import { BigNumber, Contract, hexStripZeros, JsonRpcProvider, JsonRpcSigner, Network, Web3Provider } from 'src/utils/ethers'; // prettier-ignore
 import { formatAddress } from 'src/utils/utils';
 import Onboard from 'bnc-onboard';
@@ -35,14 +35,12 @@ import { GrantRegistry, GrantRoundManager } from '@dgrants/contracts';
 const { startPolling } = useDataStore();
 const { setLastWallet } = useSettingsStore();
 const defaultChainId = SupportedChainId.MAINNET;
-const defaultProvider = new JsonRpcProvider(RPC_URL);
 
 // State variables
 let onboard: OnboardAPI; // instance of Blocknative's onboard.js library
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const rawProvider = ref<any>(); // raw provider from the user's wallet, e.g. EIP-1193 provider
-const defProvider = ref<Web3Provider | JsonRpcProvider>(markRaw(defaultProvider)); // default provider
-const provider = ref<Web3Provider | JsonRpcProvider>(markRaw(defaultProvider)); // ethers provider
+const provider = ref<Web3Provider | JsonRpcProvider>(markRaw(DEFAULT_PROVIDER)); // ethers provider
 const signer = ref<JsonRpcSigner>(); // ethers signer
 const userAddress = ref<string>(); // user's wallet address
 const userEns = ref<string | null>(); // user's ENS name
@@ -221,7 +219,7 @@ export default function useWalletStore() {
   // ----------------------------------------------------- Getters -----------------------------------------------------
   // Default to mainnet for all network-based getters
   const chainId = computed(() => (network.value?.chainId || defaultChainId) as SupportedChainId);
-  const contractProvider = computed(() => (chainId.value === DGRANTS_CHAIN_ID ? signer.value : defaultProvider));
+  const contractProvider = computed(() => (chainId.value === DGRANTS_CHAIN_ID ? signer.value : DEFAULT_PROVIDER));
   const grantRegistry = computed(() => {
     return <GrantRegistry>new Contract(GRANT_REGISTRY_ADDRESS, GRANT_REGISTRY_ABI, contractProvider.value);
   });
@@ -254,7 +252,6 @@ export default function useWalletStore() {
     isCorrectNetwork,
     isSupportedNetwork,
     multicall,
-    defaultProvider: computed(() => defProvider.value),
     network: computed(() => network.value),
     provider: computed(() => provider.value),
     signer: computed(() => signer.value),

--- a/app/src/utils/chains.ts
+++ b/app/src/utils/chains.ts
@@ -1,7 +1,7 @@
 // based off of: https://github.com/Uniswap/uniswap-interface/blob/81b13469371b3371a55b4b29c7365b1610a8d865/src/constants/chains.ts
 import { TokenInfo } from '@uniswap/token-lists';
 import {GRANT_ROUND_MANAGER_ABI as GRANT_ROUND_MANAGER_ABI_UNI_V3_ABI, GRANT_ROUND_MANAGER_UNI_V2_ABI} from 'src/utils/constants'; // prettier-ignore
-import { ContractInterface, getAddress } from 'src/utils/ethers';
+import { ContractInterface, getAddress, JsonRpcProvider } from 'src/utils/ethers';
 
 // --- Types and data ---
 export enum SupportedChainId {
@@ -210,3 +210,6 @@ export const RPC_URL = CHAIN_INFO.rpcUrl;
 export const SUBGRAPH_URL = CHAIN_INFO.subgraphUrl;
 export const START_BLOCK = CHAIN_INFO.startBlock;
 export const FILTER_BLOCK_LIMIT = CHAIN_INFO.filterBlockLimit;
+
+// --- initiate the default provider and pass as a constant ---
+export const DEFAULT_PROVIDER = new JsonRpcProvider(RPC_URL);


### PR DESCRIPTION
This PR fixes the `provider` `watch` by checking if the `contract` exists on the `provider` before populating the data store and ensures we clear all listeners on `startPolling`