### PR TITLE
Version bump updates

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/app",
-  "version": "0.0.1",
+  "version": "0.0.2-bfd43ea.0",
   "private": true,
   "scripts": {
     "clean": "rimraf dist",
@@ -14,9 +14,9 @@
     "prettier": "prettier --write ."
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.0.1",
-    "@dgrants/dcurve": "^0.0.1",
-    "@dgrants/types": "^0.0.1",
+    "@dgrants/contracts": "^0.0.2-bfd43ea.0",
+    "@dgrants/dcurve": "^0.0.2-bfd43ea.0",
+    "@dgrants/types": "^0.0.2-bfd43ea.0",
     "@fusion-icons/vue": "^0.0.0",
     "@headlessui/vue": "^1.2.0",
     "@tailwindcss/aspect-ratio": "^0.2.1",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@dgrants/contracts",
-  "version": "0.0.1",
+  "version": "0.0.2-bfd43ea.0",
   "devDependencies": {
-    "@dgrants/types": "^0.0.1",
+    "@dgrants/types": "^0.0.2-bfd43ea.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "3.4.1-solc-0.7-2",

--- a/dcurve/package.json
+++ b/dcurve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/dcurve",
-  "version": "0.0.1",
+  "version": "0.0.2-bfd43ea.0",
   "private": true,
   "description": "distribution generator for GrantCLR in dgrants",
   "keywords": [
@@ -29,8 +29,8 @@
     "extends": "../package.json"
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.0.1",
-    "@dgrants/utils": "^0.0.1",
+    "@dgrants/contracts": "^0.0.2-bfd43ea.0",
+    "@dgrants/utils": "^0.0.2-bfd43ea.0",
     "buffer": "^6.0.3",
     "ethers": "^5.4.6"
   },

--- a/package.json
+++ b/package.json
@@ -36,12 +36,12 @@
     "types": "yarn workspace @dgrants/types",
     "dcurve": "yarn workspace @dgrants/dcurve",
     "utils": "yarn workspace @dgrants/utils",
-    "bump:patch": "lerna version prepatch --preid $(git rev-parse --short HEAD) --yes --amend",
-    "bump:minor": "lerna version preminor --preid $(git rev-parse --short HEAD) --yes --amend",
-    "bump:major": "lerna version premajor --preid $(git rev-parse --short HEAD) --yes --amend",
-    "release:patch": "lerna version patch --amend --yes",
-    "release:minor": "lerna version minor --amend --yes",
-    "release:major": "lerna version major --amend --yes"
+    "bump:patch": "lerna version prepatch --preid $(git rev-parse --short HEAD) --yes",
+    "bump:minor": "lerna version preminor --preid $(git rev-parse --short HEAD) --yes",
+    "bump:major": "lerna version premajor --preid $(git rev-parse --short HEAD) --yes",
+    "release:patch": "lerna version patch --yes",
+    "release:minor": "lerna version minor --yes",
+    "release:major": "lerna version major --yes"
   },
   "husky": {
     "hooks": {

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/types",
-  "version": "0.0.1",
+  "version": "0.0.2-bfd43ea.0",
   "types": "src/index.d.ts",
   "scripts": {
     "build": "tsc -b .",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/utils",
-  "version": "0.0.1",
+  "version": "0.0.2-bfd43ea.0",
   "description": "common methods shared",
   "keywords": [
     "dgrants",


### PR DESCRIPTION
- Changes the version bump commands to create a new commit, this way the hash in the version number refers to the previous commit.
- Runs `yarn bump:patch`

One thing I noticed is that the command does not bump the version in the root package.json, which is probably ok for our purpose of ensuring the About modal shows a commit hash/version

More info in this Discord discussion: https://discord.com/channels/562828676480237578/838580829482647572/895329884518379561

![image](https://user-images.githubusercontent.com/17163988/136571445-0c078d9e-2432-445a-9c5e-1afababcdb56.png)
