### PR TITLE
chore: bump version to 0.0.6-f9d93d6.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/app",
-  "version": "0.0.5-d0316b1.0",
+  "version": "0.0.6-f9d93d6.0",
   "private": true,
   "scripts": {
     "clean": "rimraf dist",
@@ -14,9 +14,9 @@
     "prettier": "prettier --write ."
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.0.5-d0316b1.0",
-    "@dgrants/dcurve": "^0.0.5-d0316b1.0",
-    "@dgrants/types": "^0.0.5-d0316b1.0",
+    "@dgrants/contracts": "^0.0.6-f9d93d6.0",
+    "@dgrants/dcurve": "^0.0.6-f9d93d6.0",
+    "@dgrants/types": "^0.0.6-f9d93d6.0",
     "@fusion-icons/vue": "^0.0.0",
     "@headlessui/vue": "^1.2.0",
     "@tailwindcss/aspect-ratio": "^0.2.1",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@dgrants/contracts",
-  "version": "0.0.5-d0316b1.0",
+  "version": "0.0.6-f9d93d6.0",
   "devDependencies": {
-    "@dgrants/types": "^0.0.5-d0316b1.0",
+    "@dgrants/types": "^0.0.6-f9d93d6.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "3.4.1-solc-0.7-2",

--- a/dcurve/package.json
+++ b/dcurve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/dcurve",
-  "version": "0.0.5-d0316b1.0",
+  "version": "0.0.6-f9d93d6.0",
   "private": true,
   "description": "distribution generator for GrantCLR in dgrants",
   "keywords": [
@@ -29,8 +29,8 @@
     "extends": "../package.json"
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.0.5-d0316b1.0",
-    "@dgrants/utils": "^0.0.5-d0316b1.0",
+    "@dgrants/contracts": "^0.0.6-f9d93d6.0",
+    "@dgrants/utils": "^0.0.6-f9d93d6.0",
     "buffer": "^6.0.3",
     "ethers": "^5.4.6"
   },

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/types",
-  "version": "0.0.5-d0316b1.0",
+  "version": "0.0.6-f9d93d6.0",
   "types": "src/index.d.ts",
   "scripts": {
     "build": "tsc -b .",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/utils",
-  "version": "0.0.5-d0316b1.0",
+  "version": "0.0.6-f9d93d6.0",
   "description": "common methods shared",
   "keywords": [
     "dgrants",


### PR DESCRIPTION
 - @dgrants/app@0.0.6-f9d93d6.0
 - @dgrants/contracts@0.0.6-f9d93d6.0
 - @dgrants/dcurve@0.0.6-f9d93d6.0
 - @dgrants/types@0.0.6-f9d93d6.0
 - @dgrants/utils@0.0.6-f9d93d6.0