### PR TITLE
feat: adds plugin to verify contracts

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -42,6 +42,7 @@
     "vue-router": "^4.0.0-0"
   },
   "devDependencies": {
+    "@nomiclabs/hardhat-etherscan": "^2.1.6",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^8.2.2",
     "@typescript-eslint/eslint-plugin": "^4.26.1",

--- a/contracts/.env.template
+++ b/contracts/.env.template
@@ -2,3 +2,4 @@ ALCHEMY_API_KEY=yourAlchemyApiKey
 MNEMONIC=test test test test test test test test test test test junk
 DEPLOY_PRIVATE_KEY=0x
 FLEEK_STORAGE_API_KEY="yourFleekApiKey"
+ETHERSCAN_API_KEY="yourEtherscanKey"

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -1,4 +1,5 @@
 import '@nomiclabs/hardhat-waffle';
+import '@nomiclabs/hardhat-etherscan';
 import '@typechain/hardhat';
 import 'hardhat-gas-reporter';
 import 'solidity-coverage';
@@ -72,6 +73,11 @@ const config: HardhatUserConfig = {
     enabled: process.env.REPORT_GAS ? true : false,
     excludeContracts: [],
     src: './contracts',
+  },
+  etherscan: {
+    // Your API key for Etherscan/Polygonscan
+    // Obtain one at https://etherscan.io/ or https://polygonscan.com
+    apiKey: process.env.ETHERSCAN_API_KEY,
   },
   networks: {
     hardhat: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1870,6 +1870,19 @@
   resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.0.2.tgz#c472abcba0c5185aaa4ad4070146e95213c68511"
   integrity sha512-6quxWe8wwS4X5v3Au8q1jOvXYEPkS1Fh+cME5u6AwNdnI4uERvPlVjlgRWzpnb+Rrt1l/cEqiNRH9GlsBMSDQg==
 
+"@nomiclabs/hardhat-etherscan@^2.1.6":
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-2.1.6.tgz#8d1502f42adc6f7b8ef16fb917c0b5a8780cb83a"
+  integrity sha512-gCvT5fj8GbXS9+ACS3BzrX0pzYHHZqAHCb+NcipOkl2cy48FakUXlzrCf4P4sTH+Y7W10OgT62ezD1sJ+/NikQ==
+  dependencies:
+    "@ethersproject/abi" "^5.1.2"
+    "@ethersproject/address" "^5.0.2"
+    cbor "^5.0.2"
+    debug "^4.1.1"
+    fs-extra "^7.0.1"
+    node-fetch "^2.6.0"
+    semver "^6.3.0"
+
 "@nomiclabs/hardhat-waffle@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-waffle/-/hardhat-waffle-2.0.1.tgz#5d43654fba780720c5033dea240fe14f70ef4bd2"
@@ -5670,6 +5683,14 @@ caseless@^0.12.0, caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+cbor@^5.0.2:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cbor/-/cbor-5.2.0.tgz#4cca67783ccd6de7b50ab4ed62636712f287a67c"
+  integrity sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==
+  dependencies:
+    bignumber.js "^9.0.1"
+    nofilter "^1.0.4"
 
 cborg@^1.2.1:
   version "1.5.0"
@@ -13561,6 +13582,11 @@ nodent-runtime@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/nodent-runtime/-/nodent-runtime-3.2.1.tgz#9e2755d85e39f764288f0d4752ebcfe3e541e00e"
   integrity sha512-7Ws63oC+215smeKJQCxzrK21VFVlCFBkwl0MOObt0HOpVQXs3u483sAmtkF33nNqZ5rSOQjB76fgyPBmAUrtCA==
+
+nofilter@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-1.0.4.tgz#78d6f4b6a613e7ced8b015cec534625f7667006e"
+  integrity sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==
 
 nopt@3.x:
   version "3.0.6"


### PR DESCRIPTION
This PR adds `@nomiclabs/hardhat-etherscan` as a dependency to aid in verifying contracts. Thanks for getting this sorted @mk1r!!

--

- Add your etherscan/polgonscan api key to `ETHERSCAN_API_KEY` in `contracts/.env`
- Then run: (`npx hardhat verify --network mainnet DEPLOYED_CONTRACT_ADDRESS "arg1" "arg2" ...`)

```
$ yarn install

$ cd contracts

$ npx hardhat verify --network polygon "0x7D6263A49B8C35fB149f0a536BDEFE8A22E841C0"

$ npx hardhat verify --network polygon "0xea19530074A139eAd5D68e18fD304C97e4e2BAf3" "0x7D6263A49B8C35fB149f0a536BDEFE8A22E841C0" "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063"

```

