### PR TITLE
GrantCard.vue : cart buttons always visible for mobile view

### DIFF
--- a/app/src/components/GrantCard.vue
+++ b/app/src/components/GrantCard.vue
@@ -12,7 +12,7 @@
       <!--cart button-->
       <div class="absolute bottom-0 right-0">
         <button
-          class="btn opacity-0 group-hover:opacity-100"
+          class="btn opacity-100 md:opacity-0 group-hover:opacity-100"
           :class="{ 'in-cart': isInCart(id) }"
           @click.stop="isInCart(id) ? removeFromCart(id) : addToCart(id)"
         >


### PR DESCRIPTION
closes #4  - nothing fancy here - was no bug - just changed the css behaviour to have the button visible on mobile by default - can be a quick merge.

<img width="473" alt="Bildschirmfoto 2021-10-24 um 16 21 17" src="https://user-images.githubusercontent.com/569641/138598298-9bff523b-cfb7-49c7-bb1e-ad43da627230.png">
30