### PR TITLE
chore: move whitelist to data.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ yarn-error.log
 .vscode
 *.tsbuildinfo
 *.log
+.eslintcache

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/app",
-  "version": "0.0.37-7ff73da.0",
+  "version": "0.0.38-73876f1.0",
   "private": true,
   "scripts": {
     "clean": "rimraf dist",
@@ -14,8 +14,8 @@
     "prettier": "prettier --write ."
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.0.23-7ff73da.0",
-    "@dgrants/dcurve": "^0.0.23-7ff73da.0",
+    "@dgrants/contracts": "^0.0.24-73876f1.0",
+    "@dgrants/dcurve": "^0.0.24-73876f1.0",
     "@dgrants/types": "^0.0.15-2183c99.0",
     "@fusion-icons/vue": "^0.0.0",
     "@headlessui/vue": "^1.2.0",

--- a/app/src/components/GrantList.vue
+++ b/app/src/components/GrantList.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script lang="ts">
-import { watch, computed, defineComponent, onMounted, onUnmounted, PropType, ComputedRef, ref } from 'vue';
+import { watch, computed, defineComponent, onUnmounted, PropType, ComputedRef, ref } from 'vue';
 // --- App Imports ---
 import BaseFilterNav from 'src/components/BaseFilterNav.vue';
 import GrantCard from 'src/components/GrantCard.vue';
@@ -24,8 +24,6 @@ import GrantCard from 'src/components/GrantCard.vue';
 import useCartStore from 'src/store/cart';
 // --- Types ---
 import { FilterNavButton, FilterNavItem, Grant, GrantMetadataResolution } from '@dgrants/types';
-// --- Data ---
-import { DGRANTS_CHAIN_ID } from 'src/utils/chains';
 
 type SortingMode = 'newest' | 'oldest' | 'shuffle';
 
@@ -111,16 +109,6 @@ export default defineComponent({
     const grantList = computed(() =>
       grantIdList.value?.length > 0 ? createCustomGrantList(props.grants) : props.grants
     );
-
-    onMounted(async () => {
-      const uniqueStr = '?unique=' + Date.now();
-      const whitelistUrl = import.meta.env.VITE_GRANT_WHITELIST_URI;
-      if (whitelistUrl) {
-        const url = whitelistUrl + uniqueStr;
-        const json = await fetch(url).then((res) => res.json());
-        grantIdList.value = json[DGRANTS_CHAIN_ID];
-      }
-    });
 
     onUnmounted(() => {
       grantsSortingMode.value = defaultSortingMode;

--- a/app/src/views/GrantRegistryList.vue
+++ b/app/src/views/GrantRegistryList.vue
@@ -53,10 +53,10 @@ export default defineComponent({
   name: 'GrantRegistryList',
   components: { BaseHeader, GrantList, LoadingSpinner },
   setup() {
-    const { grants, grantMetadata } = useDataStore();
+    const { approvedGrants, grantMetadata } = useDataStore();
 
     return {
-      grants,
+      grants: approvedGrants,
       grantMetadata,
       ...useGrantRegistryList(),
     };

--- a/app/src/views/GrantRoundGrants.vue
+++ b/app/src/views/GrantRoundGrants.vue
@@ -25,7 +25,12 @@ import { pushRoute } from 'src/utils/utils';
 import { Breadcrumb, FilterNavButton, Grant, GrantRound } from '@dgrants/types';
 
 function useGrantRoundDetail() {
-  const { grantRounds, grantRoundMetadata: _grantRoundMetadata, grants: allGrants, grantMetadata } = useDataStore();
+  const { 
+    grantRounds,
+    grantRoundMetadata: _grantRoundMetadata,
+    approvedGrants: allGrants,
+    grantMetadata
+  } = useDataStore();
   const route = useRoute();
 
   // get a single grantRound or an empty/error object (TODO: should the typings be modified to account for an empty object?)

--- a/app/src/views/Home.vue
+++ b/app/src/views/Home.vue
@@ -213,7 +213,7 @@ export default defineComponent({
     );
 
     const {
-      grants: _grants,
+      approvedGrants: _grants,
       grantMetadata: _grantMetadata,
       grantRounds: _grantRounds,
       grantRoundMetadata: _grantRoundMetadata,

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/contracts",
-  "version": "0.0.23-7ff73da.0",
+  "version": "0.0.24-73876f1.0",
   "devDependencies": {
     "@dgrants/types": "^0.0.15-2183c99.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",

--- a/dcurve/package.json
+++ b/dcurve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/dcurve",
-  "version": "0.0.23-7ff73da.0",
+  "version": "0.0.24-73876f1.0",
   "private": true,
   "description": "distribution generator for GrantCLR in dgrants",
   "keywords": [
@@ -29,7 +29,7 @@
     "extends": "../package.json"
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.0.23-7ff73da.0",
+    "@dgrants/contracts": "^0.0.24-73876f1.0",
     "@dgrants/utils": "^0.0.15-2183c99.0",
     "buffer": "^6.0.3",
     "ethers": "^5.4.6"


### PR DESCRIPTION
## Description

- reduces calls to whitelist API
- ensure relevant grants are shown on the grants landing page
- moves the filter function to getAllGrants

Testing 

- ✅ Homepage shows filtered grants
- ✅Grants list shows filtered grants
- ✅ Next / Prev also shows filtered grants
- ✅ cart shows approved grants
- ✅ ~Access unapproved grants via URL  http://localhost:3000/#/dgrants/1?unverified=true~





closes https://github.com/dcgtc/dgrants/issues/451
closes https://github.com/dcgtc/dgrants/issues/407
closes https://github.com/dcgtc/dgrants/issues/429

~Q: Another way to go about this is to have a separate function in data.ts which just fetches the whitelist and have the frontend do the filtering
Q: As opposed to having data return grants. Would it make sense to return whitelistGrants and allGrants ?~
~What's missing ? Since whitelist is done at grant data layer you cannot access the grant URL directly.
Need to sync up with team if it makes sense a new route URL which would allow viewing unapproved grants by URL~
