### PR TITLE
Contribution Count Shows Different Numbers  - fixed #443

### DIFF
--- a/app/src/utils/constants.ts
+++ b/app/src/utils/constants.ts
@@ -41,7 +41,7 @@ export const DefaultForageConfig: LocalForageConfig = {
   // this store should be used for any on-chain/off-chain data but never user data (as we might clear it without notice)
   name: 'dGrants',
   // we can bump this version number to bust the users cache
-  version: 1,
+  version: 3,
 };
 
 // LocalForage keys

--- a/app/src/utils/constants.ts
+++ b/app/src/utils/constants.ts
@@ -41,7 +41,7 @@ export const DefaultForageConfig: LocalForageConfig = {
   // this store should be used for any on-chain/off-chain data but never user data (as we might clear it without notice)
   name: 'dGrants',
   // we can bump this version number to bust the users cache
-  version: 3,
+  version: 2,
 };
 
 // LocalForage keys

--- a/app/src/utils/data/contributions.ts
+++ b/app/src/utils/data/contributions.ts
@@ -56,7 +56,11 @@ export async function getContributions(
 
               const limit = 100;
 
-              const fetchUntilAll = async (SUBGRAPH_URL: string, before: any[] = [], skip = 0): Promise<any[]> => {
+              const fetchUntilAll = async (
+                SUBGRAPH_URL: string,
+                before: ContributionSubgraph[] = [],
+                skip = 0
+              ): Promise<any[]> => {
                 const res = await fetch(SUBGRAPH_URL, {
                   method: 'POST',
                   headers: { 'Content-Type': 'application/json' },

--- a/app/src/utils/data/contributions.ts
+++ b/app/src/utils/data/contributions.ts
@@ -56,7 +56,7 @@ export async function getContributions(
 
               const limit = 100;
 
-              const fetchUntilAll = async (SUBGRAPH_URL: string, before = [], skip = 0): Promise<any[]> => {
+              const fetchUntilAll = async (SUBGRAPH_URL: string, before: any[] = [], skip = 0): Promise<any[]> => {
                 const res = await fetch(SUBGRAPH_URL, {
                   method: 'POST',
                   headers: { 'Content-Type': 'application/json' },
@@ -80,7 +80,8 @@ export async function getContributions(
                 const json = await res.json();
 
                 if (json.data.grantDonations.length) {
-                  return await fetchUntilAll(SUBGRAPH_URL, before, skip + 1);
+                  const current = [...before, ...json.data.grantDonation];
+                  return await fetchUntilAll(SUBGRAPH_URL, current, skip + 1);
                 } else {
                   return [...before];
                 }


### PR DESCRIPTION
The root of the bug was the "first" parameter in the GraphQL query which has a default number of 100 and was not handled:
`{
                      grantDonations(where: {lastUpdatedBlockNumber_gte: ${fromBlock}, lastUpdatedBlockNumber_lte: ${blockNumber}}) {
                        grantId
                        tokenIn
                        donationAmount
                        from
                        hash
                        rounds
                        lastUpdatedBlockNumber
                      }
                    }`

so whenever the length of the contributions would go more than 100, the system would act inconsistently.  I created a recursive function that will continue to fetch contributions until there is no more left.

_It only works if the cached data is properly set before "fromBlock" which is not unless there are less than 100 contributions_ **So do the hard refresh and remove the cached data**