### PR TITLE
fix: moves metaPtr update to getGrantRound

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/app",
-  "version": "0.0.32-0cdd45c.0",
+  "version": "0.0.33-5aa963e.0",
   "private": true,
   "scripts": {
     "clean": "rimraf dist",
@@ -14,8 +14,8 @@
     "prettier": "prettier --write ."
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.0.18-0cdd45c.0",
-    "@dgrants/dcurve": "^0.0.18-0cdd45c.0",
+    "@dgrants/contracts": "^0.0.19-5aa963e.0",
+    "@dgrants/dcurve": "^0.0.19-5aa963e.0",
     "@dgrants/types": "^0.0.15-2183c99.0",
     "@fusion-icons/vue": "^0.0.0",
     "@headlessui/vue": "^1.2.0",

--- a/app/src/store/data.ts
+++ b/app/src/store/data.ts
@@ -204,8 +204,6 @@ export default function useDataStore() {
 
     // Set up watchers on the grantRounds
     grantRoundsList.forEach(async (grantRound) => {
-      // change ipfs endpoint
-      grantRound.metaPtr = grantRound.metaPtr.replace('https://ipfs-dev', 'https://ipfs');
       // open the rounds contract
       const roundContract = new Contract(grantRound.address, GRANT_ROUND_ABI, provider.value);
       // open the rounds contract

--- a/app/src/utils/data/grantRounds.ts
+++ b/app/src/utils/data/grantRounds.ts
@@ -230,7 +230,6 @@ export async function getGrantRound(blockNumber: number, grantRoundAddress: stri
             metadataAdmin,
             payoutAdmin,
             registryAddress,
-            metaPtr,
             hasPaidOut,
             donationToken: donationToken,
             matchingToken: matchingToken,
@@ -244,6 +243,8 @@ export async function getGrantRound(blockNumber: number, grantRoundAddress: stri
                 : 'Completed',
             registry: GRANT_REGISTRY_ADDRESS,
             error: undefined,
+            // change ipfs endpoint
+            metaPtr: metaPtr.replace('https://ipfs-dev', 'https://ipfs'),
           } as GrantRound,
         };
 

--- a/app/src/utils/data/grants.ts
+++ b/app/src/utils/data/grants.ts
@@ -121,6 +121,7 @@ export async function getAllGrants(forceRefresh = false) {
         grants: (Object.values(_lsGrants) as Grant[]).map((grant) => {
           // change ipfs endpoint
           grant.metaPtr = grant.metaPtr.replace('https://ipfs-dev', 'https://ipfs');
+
           return {
             ...grant,
           } as Grant;

--- a/app/src/views/Home.vue
+++ b/app/src/views/Home.vue
@@ -150,7 +150,7 @@
 
 <script lang="ts">
 // --- Types ---
-import { Breadcrumb, FilterNavItem, FilterNavButton } from '@dgrants/types';
+import { Breadcrumb, FilterNavItem, FilterNavButton, Grant } from '@dgrants/types';
 // --- Utils ---
 import { computed, defineComponent, ref, watch } from 'vue';
 import { BigNumber } from 'ethers';
@@ -221,7 +221,7 @@ export default defineComponent({
     } = useDataStore();
 
     // --- Data sources ---
-    const grants = computed(() => (_grants?.value ? shuffle(_grants?.value).slice(0, 8) : _grants?.value));
+    const grants = computed(() => (_grants?.value ? shuffle(_grants?.value).slice(0, 8) : _grants?.value) as Grant[]);
     const grantMetadata = computed(() => _grantMetadata.value);
     const grantRounds = computed(() => _grantRounds.value);
     const grantRoundMetadata = computed(() => _grantRoundMetadata.value);

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/contracts",
-  "version": "0.0.18-0cdd45c.0",
+  "version": "0.0.19-5aa963e.0",
   "devDependencies": {
     "@dgrants/types": "^0.0.15-2183c99.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",

--- a/dcurve/package.json
+++ b/dcurve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/dcurve",
-  "version": "0.0.18-0cdd45c.0",
+  "version": "0.0.19-5aa963e.0",
   "private": true,
   "description": "distribution generator for GrantCLR in dgrants",
   "keywords": [
@@ -29,7 +29,7 @@
     "extends": "../package.json"
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.0.18-0cdd45c.0",
+    "@dgrants/contracts": "^0.0.19-5aa963e.0",
     "@dgrants/utils": "^0.0.15-2183c99.0",
     "buffer": "^6.0.3",
     "ethers": "^5.4.6"


### PR DESCRIPTION
This PR will move the metaPtr str replacement into the utility function which syncs the data with storage (this corrects the ptr currently stored in indexedDB without the need for cache busting).

--

Fixes: #467 