### PR TITLE
Breadcrumb now works as expected in #464

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/app",
-  "version": "0.0.40-303466f.0",
+  "version": "0.0.41-de1b667.0",
   "private": true,
   "scripts": {
     "clean": "rimraf dist",
@@ -14,9 +14,9 @@
     "prettier": "prettier --write ."
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.0.26-303466f.0",
-    "@dgrants/dcurve": "^0.0.26-303466f.0",
-    "@dgrants/types": "^0.0.15-2183c99.0",
+    "@dgrants/contracts": "^0.0.27-de1b667.0",
+    "@dgrants/dcurve": "^0.0.27-de1b667.0",
+    "@dgrants/types": "^0.0.16-de1b667.0",
     "@fusion-icons/vue": "^0.0.0",
     "@headlessui/vue": "^1.2.0",
     "@tailwindcss/aspect-ratio": "^0.2.1",

--- a/app/src/components/GrantCard.vue
+++ b/app/src/components/GrantCard.vue
@@ -1,7 +1,16 @@
 <!-- GrantCard -->
 
 <template>
-  <figure class="group cursor-pointer" @click="pushRoute({ name: 'dgrants-id', params: { id: id.toString() } })">
+  <figure
+    class="group cursor-pointer"
+    @click="
+      pushRoute({
+        name: 'dgrants-id',
+        params: { id: id.toString() },
+        query: roundAddress && roundName ? { roundAddress: roundAddress, roundName: roundName } : {},
+      })
+    "
+  >
     <!--img-->
     <div class="relative">
       <!--img-->
@@ -70,6 +79,8 @@ export default defineComponent({
     name: { type: String, required: true },
     imgurl: { type: String, required: true },
     ownerAddress: { type: String, required: true },
+    roundAddress: { type: String, default: '' },
+    roundName: { type: String, default: '' },
   },
   components: { CartIcon },
   setup(props) {

--- a/app/src/components/GrantList.vue
+++ b/app/src/components/GrantList.vue
@@ -9,6 +9,8 @@
           :name="(grantMetadata && grantMetadata[grant.metaPtr]?.name) || '...'"
           :ownerAddress="grant.owner"
           :imgurl="(grantMetadata && grantMetadata[grant.metaPtr]?.logoURI) || '/placeholder_grant.svg'"
+          :roundAddress="roundAddress"
+          :roundName="roundName"
         />
       </li>
     </ul>
@@ -103,6 +105,8 @@ export default defineComponent({
     grants: { type: Array as PropType<Grant[]>, required: true },
     grantMetadata: { type: Object as PropType<Record<string, GrantMetadataResolution>>, required: true },
     button: { type: Object as PropType<FilterNavButton>, required: false },
+    roundAddress: { type: String, default: '' },
+    roundName: { type: String, default: '' },
   },
   setup(props) {
     const { addToCart, isInCart, removeFromCart } = useCartStore();

--- a/app/src/views/GrantRegistryGrantDetail.vue
+++ b/app/src/views/GrantRegistryGrantDetail.vue
@@ -376,22 +376,40 @@ function useGrantDetail() {
   );
 
   // --- BaseHeader Navigation ---
-  const breadcrumb = computed(
-    () =>
-      <Breadcrumb[]>[
-        {
-          displayName: 'dgrants',
-          routeTarget: { name: 'Home' },
-        },
-        {
-          displayName: 'registry',
-          routeTarget: { name: 'dgrants' },
-        },
-        {
-          displayName: `#${grantId.value}`,
-          routeTarget: { name: 'dgrants-id', params: { id: grantId.value } },
-        },
-      ]
+  const breadcrumb = computed(() =>
+    route.query.roundName && route.query.roundAddress
+      ? <Breadcrumb[]>[
+          {
+            displayName: 'dgrants',
+            routeTarget: { name: 'Home' },
+          },
+          {
+            displayName: 'rounds',
+            routeTarget: { name: 'dgrants-rounds-list' },
+          },
+          {
+            displayName: route.query.roundName,
+            routeTarget: { name: 'dgrants-round', params: { address: route.query.roundAddress } },
+          },
+          {
+            displayName: `#${grantId.value}`,
+            routeTarget: { name: 'dgrants-id', params: { id: grantId.value } },
+          },
+        ]
+      : <Breadcrumb[]>[
+          {
+            displayName: 'dgrants',
+            routeTarget: { name: 'Home' },
+          },
+          {
+            displayName: 'registry',
+            routeTarget: { name: 'dgrants' },
+          },
+          {
+            displayName: `#${grantId.value}`,
+            routeTarget: { name: 'dgrants-id', params: { id: grantId.value } },
+          },
+        ]
   );
   const getGrantTargetFor = (grantid: number) => {
     if (!grants.value) return undefined; // array type unsupported

--- a/app/src/views/GrantRound.vue
+++ b/app/src/views/GrantRound.vue
@@ -201,23 +201,24 @@ function useGrantRoundDetail() {
   const txHash = ref<string>();
 
   // --- BaseHeader Navigation ---
-  const breadcrumb = computed(
-    () =>
-      <Breadcrumb[]>[
-        {
-          displayName: 'dgrants',
-          routeTarget: { name: 'Home' },
-        },
-        {
-          displayName: 'rounds',
-          routeTarget: { name: 'dgrants-rounds-list' },
-        },
-        {
-          displayName: `#${formatAddress(grantRoundAddress.value.toString())}`,
-          routeTarget: { name: 'dgrants-round', params: { address: grantRoundAddress.value } },
-        },
-      ]
-  );
+  const breadcrumb = computed(() => {
+    return <Breadcrumb[]>[
+      {
+        displayName: 'dgrants',
+        routeTarget: { name: 'Home' },
+      },
+      {
+        displayName: 'rounds',
+        routeTarget: { name: 'dgrants-rounds-list' },
+      },
+      {
+        displayName: grantRoundMetadata.value?.name
+          ? grantRoundMetadata.value?.name
+          : formatAddress(grantRoundAddress.value.toString()),
+        routeTarget: { name: 'dgrants-round', params: { address: grantRoundAddress.value } },
+      },
+    ];
+  });
 
   // get a single grantRound or an empty/error object (TODO: should the typings be modified to account for an empty object?)
   const grantRound = computed(() => {

--- a/app/src/views/GrantRoundGrants.vue
+++ b/app/src/views/GrantRoundGrants.vue
@@ -2,7 +2,14 @@
   <template v-if="hasLoadedHeader">
     <BaseHeader :name="title" :breadcrumbContent="breadcrumb" />
     <!-- General filters -->
-    <GrantList v-if="hasLoadedGrants" :button="filterNavButton" :grants="grants" :grantMetadata="grantMetadata" />
+    <GrantList
+      v-if="hasLoadedGrants"
+      :button="filterNavButton"
+      :grants="grants"
+      :grantMetadata="grantMetadata"
+      :roundAddress="grantRound?.address"
+      :roundName="grantRoundMetadata?.name"
+    />
   </template>
 
   <LoadingSpinner v-else />
@@ -72,6 +79,10 @@ function useGrantRoundDetail() {
           routeTarget: { name: 'Home' },
         },
         {
+          displayName: 'rounds',
+          routeTarget: { name: 'dgrants-rounds-list' },
+        },
+        {
           displayName: grantRoundMetadata.value?.name,
           routeTarget: { name: 'dgrants-round', params: { address: grantRound.value?.address } },
         },
@@ -91,6 +102,7 @@ function useGrantRoundDetail() {
     filterNavButton,
     title,
     grants,
+    grantRound,
     grantMetadata,
     grantRoundMetadata,
     hasLoadedHeader,

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@dgrants/contracts",
-  "version": "0.0.26-303466f.0",
+  "version": "0.0.27-de1b667.0",
   "devDependencies": {
-    "@dgrants/types": "^0.0.15-2183c99.0",
+    "@dgrants/types": "^0.0.16-de1b667.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "3.4.1-solc-0.7-2",

--- a/dcurve/package.json
+++ b/dcurve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/dcurve",
-  "version": "0.0.26-303466f.0",
+  "version": "0.0.27-de1b667.0",
   "private": true,
   "description": "distribution generator for GrantCLR in dgrants",
   "keywords": [
@@ -29,8 +29,8 @@
     "extends": "../package.json"
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.0.26-303466f.0",
-    "@dgrants/utils": "^0.0.15-2183c99.0",
+    "@dgrants/contracts": "^0.0.27-de1b667.0",
+    "@dgrants/utils": "^0.0.16-de1b667.0",
     "buffer": "^6.0.3",
     "ethers": "^5.4.6"
   },

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/types",
-  "version": "0.0.15-2183c99.0",
+  "version": "0.0.16-de1b667.0",
   "types": "src/index.d.ts",
   "scripts": {
     "build": "tsc -b .",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/utils",
-  "version": "0.0.15-2183c99.0",
+  "version": "0.0.16-de1b667.0",
   "description": "common methods shared",
   "keywords": [
     "dgrants",


### PR DESCRIPTION
fixed #464 

- [x] View a round and the breadcrumbs are DGRANTS > ROUNDS > #0x123. This should either (1) have the round name instead of address, or (2) remove the pound sign in front of the address
- [x] From that page, click "See Grants" and now breadcrumbs are DGRANTS > DGRANTS PROOF-OF-CONCEPT >, but it should be DGRANTS > ROUNDS > DGRANTS PROOF-OF-CONCEPT >
- [x] Then click on the "Octavio leaving" grant, and breadcrumbs are DGRANTS > REGISTRY > Re-import Original Prototype Contracts #5, but (1) ideally the grant number is replaced with the name, and (2) the breadcrumbs changed entirely and no longer show round information


=====
For the last one, I think it's pretty nice already but @scco  should decide:

![Screen Shot 1400-08-12 at 16 43 11](https://user-images.githubusercontent.com/64213712/140066347-2b4cf0ba-d5a0-40c9-91d0-5b7df98aa3fb.png)

