### PR TITLE
Fixes performance issues

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/app",
-  "version": "0.2.6-b2b9f5d.0",
+  "version": "0.2.7-7be4518.0",
   "private": true,
   "scripts": {
     "clean": "rimraf dist",
@@ -14,9 +14,9 @@
     "prettier": "prettier --write ."
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.2.6-b2b9f5d.0",
-    "@dgrants/dcurve": "^0.2.6-b2b9f5d.0",
-    "@dgrants/types": "^0.2.6-b2b9f5d.0",
+    "@dgrants/contracts": "^0.2.7-7be4518.0",
+    "@dgrants/dcurve": "^0.2.7-7be4518.0",
+    "@dgrants/types": "^0.2.7-7be4518.0",
     "@fusion-icons/vue": "^0.0.0",
     "@headlessui/vue": "^1.2.0",
     "@tailwindcss/aspect-ratio": "^0.2.1",

--- a/app/src/utils/constants.ts
+++ b/app/src/utils/constants.ts
@@ -41,7 +41,7 @@ export const DefaultForageConfig: LocalForageConfig = {
   // this store should be used for any on-chain/off-chain data but never user data (as we might clear it without notice)
   name: 'dGrants',
   // we can bump this version number to bust the users cache
-  version: 2,
+  version: 3,
 };
 
 // LocalForage keys

--- a/app/src/utils/utils.ts
+++ b/app/src/utils/utils.ts
@@ -417,19 +417,20 @@ export const shuffle = (unshuffled: Grant[] | GrantRound[]) => {
 /**
  * @notice Recursively grab every page of results
  *
- * @param {string} url the url we will recursively fetch from
- * @param {string} key the key in the response object which holds results
- * @param {function} query a function which will return the query string (with the page in place)
- * @param {array} before the current array of objects
- * @param {number} page the page we want to fetch
+ * @param string url the url we will recursively fetch from
+ * @param string key the key in the response object which holds results
+ * @param function query a function which will return the query string (with the page in place)
+ * @param array before the current array of objects
+ * @param number page the page we want to fetch
  */
 export const recursiveGraphFetch = async (
   url: string,
   key: string,
   query: (page: number) => string,
-  before: any[] = [],
+  before: any[] = [], // eslint-disable-line @typescript-eslint/no-explicit-any
   page = 0
-): Promise<any[]> => {
+): // eslint-disable-next-line @typescript-eslint/no-explicit-any
+Promise<any[]> => {
   // fetch this page of results
   const res = await fetch(url, {
     method: 'POST',

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@dgrants/contracts",
-  "version": "0.2.6-b2b9f5d.0",
+  "version": "0.2.7-7be4518.0",
   "devDependencies": {
-    "@dgrants/types": "^0.2.6-b2b9f5d.0",
+    "@dgrants/types": "^0.2.7-7be4518.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "3.4.1-solc-0.7-2",

--- a/dcurve/package.json
+++ b/dcurve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/dcurve",
-  "version": "0.2.6-b2b9f5d.0",
+  "version": "0.2.7-7be4518.0",
   "private": true,
   "description": "distribution generator for GrantCLR in dgrants",
   "keywords": [
@@ -29,8 +29,8 @@
     "extends": "../package.json"
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.2.6-b2b9f5d.0",
-    "@dgrants/utils": "^0.2.6-b2b9f5d.0",
+    "@dgrants/contracts": "^0.2.7-7be4518.0",
+    "@dgrants/utils": "^0.2.7-7be4518.0",
     "buffer": "^6.0.3",
     "ethers": "^5.4.6"
   },

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/types",
-  "version": "0.2.6-b2b9f5d.0",
+  "version": "0.2.7-7be4518.0",
   "types": "src/index.d.ts",
   "scripts": {
     "build": "tsc -b .",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/utils",
-  "version": "0.2.6-b2b9f5d.0",
+  "version": "0.2.7-7be4518.0",
   "description": "common methods shared",
   "keywords": [
     "dgrants",


### PR DESCRIPTION
This PR fixes the performance problems we have been experiencing...

- We we're making RPC calls for every block after the last event recorded by the graph to ensure that we had received all events up to the current block (incase the graph was behind for whatever reason) - however, because no new events had occurred for the last few days, we inadvertently reintroduced the issue which led us to move to the graph in the first place. Instead of attempting to close this gap, we will now only use RPC calls to fetch initial data as a fallback for if/when the graph fails (such as when there is no `SUBGRAPH_URL` for the chain). This requires additional testing - we still want to make sure the graph hasn't fallen behind, but we likely only need to introduce a constant buffer rather than starting from the last event the graph recorded (as this is unlikely to correlate with the last block the graph saw).

- Pulls @Ajand's fix from #460 and creates a utility from it (great job Ajand!) - this solves the problem of not fetching all data from the graph

- As @jjwoz suggested, `useDataStore` was being called from many places which was causing us to initialise multiple instances of the store, this is likely the root cause of the race condition @Ajand had worked around in #460.

--

Closes: #443
Closes: #485
