### PR TITLE
update metaPtr type

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/app",
-  "version": "0.0.41-de1b667.0",
+  "version": "0.1.0-6941e2e.0",
   "private": true,
   "scripts": {
     "clean": "rimraf dist",
@@ -14,9 +14,9 @@
     "prettier": "prettier --write ."
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.0.27-de1b667.0",
-    "@dgrants/dcurve": "^0.0.27-de1b667.0",
-    "@dgrants/types": "^0.0.16-de1b667.0",
+    "@dgrants/contracts": "^0.1.0-6941e2e.0",
+    "@dgrants/dcurve": "^0.1.0-6941e2e.0",
+    "@dgrants/types": "^0.1.0-6941e2e.0",
     "@fusion-icons/vue": "^0.0.0",
     "@headlessui/vue": "^1.2.0",
     "@tailwindcss/aspect-ratio": "^0.2.1",

--- a/app/src/components/GrantList.vue
+++ b/app/src/components/GrantList.vue
@@ -6,9 +6,9 @@
       <li v-for="grant in sortedGrants" :key="grant.id.toString()">
         <GrantCard
           :id="grant.id"
-          :name="(grantMetadata && grantMetadata[grant.metaPtr]?.name) || '...'"
+          :name="(grantMetadata && grantMetadata[metadataId(grant.metaPtr)]?.name) || '...'"
           :ownerAddress="grant.owner"
-          :imgurl="(grantMetadata && grantMetadata[grant.metaPtr]?.logoURI) || '/placeholder_grant.svg'"
+          :imgurl="(grantMetadata && grantMetadata[metadataId(grant.metaPtr)]?.logoURI) || '/placeholder_grant.svg'"
           :roundAddress="roundAddress"
           :roundName="roundName"
         />
@@ -19,11 +19,12 @@
 
 <script lang="ts">
 import { watch, computed, defineComponent, onUnmounted, PropType, ComputedRef, ref } from 'vue';
-// --- App Imports ---
+// --- Components ---
 import BaseFilterNav from 'src/components/BaseFilterNav.vue';
 import GrantCard from 'src/components/GrantCard.vue';
-// --- Store ---
+// --- Store + methods---
 import useCartStore from 'src/store/cart';
+import { metadataId } from 'src/utils/utils';
 // --- Types ---
 import { FilterNavButton, FilterNavItem, Grant, GrantMetadataResolution } from '@dgrants/types';
 
@@ -123,6 +124,7 @@ export default defineComponent({
       isInCart,
       addToCart,
       removeFromCart,
+      metadataId,
     };
   },
 });

--- a/app/src/components/GrantReviewList.vue
+++ b/app/src/components/GrantReviewList.vue
@@ -5,9 +5,9 @@
       <li v-for="grant in sortedGrants" :key="grant.id.toString()">
         <GrantCard
           :id="grant.id"
-          :name="(grantMetadata && grantMetadata[grant.metaPtr]?.name) || '...'"
+          :name="(grantMetadata && grantMetadata[metadataId(grant.metaPtr)]?.name) || '...'"
           :ownerAddress="grant.owner"
-          :imgurl="(grantMetadata && grantMetadata[grant.metaPtr]?.logoURI) || '/placeholder_grant.svg'"
+          :imgurl="(grantMetadata && grantMetadata[metadataId(grant.metaPtr)]?.logoURI) || '/placeholder_grant.svg'"
         />
       </li>
     </ul>
@@ -16,7 +16,7 @@
 
 <script lang="ts">
 import { watch, computed, defineComponent, onMounted, onUnmounted, PropType, ComputedRef, ref } from 'vue';
-// --- App Imports ---
+// --- Components ---
 import GrantCard from 'src/components/GrantCard.vue';
 // --- Store ---
 import useCartStore from 'src/store/cart';
@@ -24,6 +24,7 @@ import useCartStore from 'src/store/cart';
 import { FilterNavItem, Grant, GrantMetadataResolution } from '@dgrants/types';
 // --- Utils ---
 import { DGRANTS_CHAIN_ID } from 'src/utils/chains';
+import { metadataId } from 'src/utils/utils';
 
 type SortingMode = 'newest' | 'oldest' | 'shuffle';
 
@@ -122,9 +123,10 @@ export default defineComponent({
 
     return {
       ...useSortedGrants(grantList),
-      isInCart,
       addToCart,
+      isInCart,
       removeFromCart,
+      metadataId,
     };
   },
 });

--- a/app/src/store/cart.ts
+++ b/app/src/store/cart.ts
@@ -11,7 +11,7 @@ import { CartItem, CartItemOptions, CartPrediction, CartPredictions } from 'src/
 import { SupportedChainId, SUPPORTED_TOKENS, SUPPORTED_TOKENS_MAPPING, WETH_ADDRESS } from 'src/utils/chains';
 import { ERC20_ABI, ETH_ADDRESS, WAD } from 'src/utils/constants';
 import { BigNumber, BigNumberish, BytesLike, Contract, ContractTransaction, formatUnits, getAddress, hexDataSlice, isAddress, MaxUint256, parseUnits } from 'src/utils/ethers'; // prettier-ignore
-import { assertSufficientBalance } from 'src/utils/utils';
+import { assertSufficientBalance, metadataId } from 'src/utils/utils';
 import useDataStore from 'src/store/data';
 import useWalletStore from 'src/store/wallet';
 import { getPredictedMatchingForAmount } from '@dgrants/dcurve';
@@ -386,7 +386,7 @@ export default function useCartStore() {
     return cart.value
       .map((item) =>
         (grantRounds.value || []).reduce((inRound: boolean, round) => {
-          return inRound || grantRoundMetadata.value[round.metaPtr].grants?.includes(item.grantId) || false;
+          return inRound || grantRoundMetadata.value[metadataId(round.metaPtr)].grants?.includes(item.grantId) || false;
         }, false)
       )
       .reduce((inRound, isInRound) => inRound || isInRound, false);
@@ -403,7 +403,7 @@ export default function useCartStore() {
       // collect the matching values for each grant in each round
       _predictions[item.grantId] = (grantRounds.value || []).map((round) => {
         let matching: number | boolean = false;
-        const metadata = grantRoundMetadata.value[round.metaPtr];
+        const metadata = grantRoundMetadata.value[metadataId(round.metaPtr)];
         if (metadata && metadata.grants?.includes(item.grantId)) {
           // all calculations are denominated in the rounds donationToken
           const roundToken = round.donationToken;

--- a/app/src/store/data.ts
+++ b/app/src/store/data.ts
@@ -37,6 +37,7 @@ import {
 } from 'src/utils/chains';
 import { DefaultStorage, getStorageKey, setStorageKey } from 'src/utils/data/utils';
 import { GRANT_ROUND_ABI, ERC20_ABI } from 'src/utils/constants';
+import { metadataId } from 'src/utils/utils';
 
 // --- Parameters required ---
 const { provider, grantRoundManager, network } = useWalletStore();
@@ -114,7 +115,6 @@ export default function useDataStore() {
       return grants;
     }, {});
 
-
     const approvedGrantsList = await getApprovedGrants(grantsData.grants);
 
     // Pull state from each GrantRound
@@ -158,7 +158,7 @@ export default function useDataStore() {
         // only do predictions once after resolving all grantRounds
         const gotAllMetadata = !grantRoundsList
           .map((grantRound: GrantRound) => {
-            return grantRoundMetadata.value[grantRound.metaPtr].status === 'resolved';
+            return grantRoundMetadata.value[metadataId(grantRound.metaPtr)].status === 'resolved';
           })
           .includes(false);
         // calculate predictions after we've got all rounds metadata
@@ -296,7 +296,7 @@ export default function useDataStore() {
    *
    * @param grants Grant[]
    */
-   async function getApprovedGrants(grants: Grant[]) {
+  async function getApprovedGrants(grants: Grant[]) {
     const uniqueStr = '?unique=' + Date.now();
 
     const whitelistUrl = import.meta.env.VITE_GRANT_WHITELIST_URI;
@@ -308,7 +308,7 @@ export default function useDataStore() {
 
     return grants;
   }
-  
+
   /**
    * @notice Call this method to poll now, then poll on each new block
    */

--- a/app/src/utils/chains.ts
+++ b/app/src/utils/chains.ts
@@ -139,7 +139,7 @@ export const ALL_CHAIN_INFO: ChainInfo = {
     grantRoundManager: '0xB40a90fdB0163cA5C82D1959dB7e56B50A0dC016',
     grantRoundManagerAbi: GRANT_ROUND_MANAGER_ABI_UNI_V3_ABI,
     multicall: '0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696',
-    rpcUrl: `https://eth-mainnet.alchemyapi.io/v2/${ALCHEMY_API_KEY}`,
+    rpcUrl: 'http://127.0.0.1:8545/',
     subgraphUrl: false,
     startBlock: 13186294,
     filterBlockLimit: -1,

--- a/app/src/utils/constants.ts
+++ b/app/src/utils/constants.ts
@@ -41,7 +41,7 @@ export const DefaultForageConfig: LocalForageConfig = {
   // this store should be used for any on-chain/off-chain data but never user data (as we might clear it without notice)
   name: 'dGrants',
   // we can bump this version number to bust the users cache
-  version: 1,
+  version: 2,
 };
 
 // LocalForage keys

--- a/app/src/utils/data/contributions.ts
+++ b/app/src/utils/data/contributions.ts
@@ -74,8 +74,6 @@ export async function getContributions(
               const json = await res.json();
               // update each of the grants
               json.data.grantDonations.forEach((contribution: ContributionSubgraph) => {
-                // update to most recent block collected
-                fromBlock = Math.max(fromBlock, contribution.lastUpdatedBlockNumber);
                 const grantId = BigNumber.from(contribution.grantId).toNumber();
                 _lsContributions[`${contribution.hash}-${grantId}`] = {
                   grantId: grantId,
@@ -89,6 +87,8 @@ export async function getContributions(
                   blockNumber: contribution.lastUpdatedBlockNumber,
                 };
               });
+              // update to most recent block collected
+              fromBlock = blockNumber;
             } catch {
               console.log('dGrants: Data fetch error - Subgraph request failed');
             }

--- a/app/src/utils/data/grantRounds.ts
+++ b/app/src/utils/data/grantRounds.ts
@@ -73,11 +73,11 @@ export async function getAllGrantRounds(forceRefresh = false) {
             const json = await res.json();
             // update each of the grants
             json.data.grantRounds.forEach((grantRound: GrantRoundSubgraph) => {
-              // update to most recent block collected
-              fromBlock = Math.max(fromBlock, grantRound.lastUpdatedBlockNumber);
               // collate grantRoundAddresses
               _lsRoundAddresses.add(getAddress(grantRound.address));
             });
+            // update to most recent block collected
+            fromBlock = latestBlockNumber;
           } catch {
             console.log('dGrants: Data fetch error - Subgraph request failed');
           }

--- a/app/src/utils/data/grantRounds.ts
+++ b/app/src/utils/data/grantRounds.ts
@@ -243,8 +243,7 @@ export async function getGrantRound(blockNumber: number, grantRoundAddress: stri
                 : 'Completed',
             registry: GRANT_REGISTRY_ADDRESS,
             error: undefined,
-            // change ipfs endpoint
-            metaPtr: metaPtr.replace('https://ipfs-dev', 'https://ipfs'),
+            metaPtr,
           } as GrantRound,
         };
 

--- a/app/src/utils/data/grantRounds.ts
+++ b/app/src/utils/data/grantRounds.ts
@@ -13,10 +13,11 @@ import { LocalForageData } from 'src/types';
 import useWalletStore from 'src/store/wallet';
 import { BigNumber, BigNumberish, Contract, Event } from 'ethers';
 import { formatUnits, getAddress } from 'ethers/lib/utils';
-import { formatNumber, callMulticallContract, batchFilterCall } from '../utils';
+import { formatNumber, callMulticallContract, batchFilterCall, metadataId } from '../utils';
 import { syncStorage } from 'src/utils/data/utils';
 import { CLR, linear, InitArgs } from '@dgrants/dcurve';
 import { filterContributionsByGrantId, filterContributionsByGrantRound } from './contributions';
+import { getMetadata } from './ipfs';
 // --- Constants ---
 import { START_BLOCK, SUPPORTED_TOKENS_MAPPING, GRANT_REGISTRY_ADDRESS, SUBGRAPH_URL } from 'src/utils/chains';
 import {
@@ -27,7 +28,6 @@ import {
   grantRoundsCLRDataKeyPrefix,
 } from 'src/utils/constants';
 import { Ref } from 'vue';
-import { getMetadata } from './ipfs';
 
 const { grantRoundManager, provider } = useWalletStore();
 
@@ -310,7 +310,7 @@ export async function getGrantRoundGrantData(
         (LocalForageData && (LocalForageData.blockNumber || START_BLOCK) < blockNumber)
       ) {
         // get the rounds metadata
-        const metadata = grantRoundMetadata[grantRound.metaPtr];
+        const metadata = grantRoundMetadata[metadataId(grantRound.metaPtr)];
         // total the number of contributions being considered in the current prediction
         const oldDonationCount = _lsGrantDonations.length;
         // fetch contributions
@@ -410,7 +410,7 @@ export function getGrantsGrantRoundDetails(
 
   return rounds
     .map((round) => {
-      const metadata = roundsMetadata[round.metaPtr];
+      const metadata = roundsMetadata[metadataId(round.metaPtr)];
       if (metadata && metadata.grants?.includes(grantId)) {
         // get the predictions for this grant in this round
         const predictions = getPredictionsForGrantInRound(grantId, grantRoundsCLRData[round.address]);

--- a/app/src/utils/data/grants.ts
+++ b/app/src/utils/data/grants.ts
@@ -63,8 +63,6 @@ export async function getAllGrants(forceRefresh = false) {
             const json = await res.json();
             // update each of the grants
             json.data.grants.forEach((grant: GrantSubgraph) => {
-              // update to most recent block collected
-              fromBlock = Math.max(fromBlock, grant.lastUpdatedBlockNumber);
               const grantId = BigNumber.from(grant.id).toNumber();
               _lsGrants[grantId] = {
                 id: grantId,
@@ -73,6 +71,8 @@ export async function getAllGrants(forceRefresh = false) {
                 metaPtr: grant.metaPtr,
               } as Grant;
             });
+            // update to most recent block collected
+            fromBlock = latestBlockNumber;
           } catch {
             console.log('dGrants: Data fetch error - Subgraph request failed');
           }

--- a/app/src/utils/data/grants.ts
+++ b/app/src/utils/data/grants.ts
@@ -119,12 +119,7 @@ export async function getAllGrants(forceRefresh = false) {
       // hydrate data from localStorage
       const grants = {
         grants: (Object.values(_lsGrants) as Grant[]).map((grant) => {
-          // change ipfs endpoint
-          grant.metaPtr = grant.metaPtr.replace('https://ipfs-dev', 'https://ipfs');
-
-          return {
-            ...grant,
-          } as Grant;
+          return { ...grant } as Grant;
         }),
       };
 

--- a/app/src/utils/utils.ts
+++ b/app/src/utils/utils.ts
@@ -7,7 +7,7 @@ import { Event } from 'ethers';
 import { BigNumber, BigNumberish, commify, Contract, ContractTransaction, isAddress, Logger } from 'src/utils/ethers';
 import { BatchFilterQuery, EtherscanGroup } from 'src/types';
 import useWalletStore from 'src/store/wallet';
-import { Grant, GrantRound } from '@dgrants/types';
+import { Grant, GrantRound, MetaPtr } from '@dgrants/types';
 import { formatUnits } from 'src/utils/ethers';
 import { ETH_ADDRESS } from 'src/utils/constants';
 import { ETHERSCAN_BASE_URL, FILTER_BLOCK_LIMIT, SUPPORTED_TOKENS_MAPPING, WETH_ADDRESS } from 'src/utils/chains';
@@ -69,6 +69,12 @@ export function urlFromTwitterHandle(handle: string) {
 // Clean twitter url and return the handle
 export function cleanTwitterUrl(url: string | undefined) {
   return url ? url.replace('https://twitter.com/', '') : undefined;
+}
+
+// Given a metadata pointer object, return a stringified version that can be used as an object key
+export function metadataId(metaPtr: MetaPtr) {
+  const keys = Object.keys(metaPtr).sort(); // ensure deterministic ordering of keys
+  return keys.map((key) => metaPtr[<keyof typeof metaPtr>key].toString()).join('-'); // stringify and join all values
 }
 
 // --- Validation ---

--- a/app/src/views/Cart.vue
+++ b/app/src/views/Cart.vue
@@ -66,7 +66,7 @@
                 <figure class="aspect-w-16 aspect-h-9 shadow-light">
                   <img
                     class="w-full h-full object-center object-cover group-hover:opacity-90"
-                    :src="grantMetadata[item.metaPtr]?.logoURI || '/placeholder_grant.svg'"
+                    :src="grantMetadata[metadataId(item.metaPtr)]?.logoURI || '/placeholder_grant.svg'"
                   />
                 </figure>
               </div>
@@ -77,7 +77,7 @@
                   class="link"
                   @click="pushRoute({ name: 'dgrants-id', params: { id: BigNumber.from(item.grantId).toString() } })"
                 >
-                  {{ grantMetadata[item.metaPtr]?.name }}
+                  {{ grantMetadata[metadataId(item.metaPtr)]?.name }}
                 </span>
               </div>
 
@@ -230,7 +230,7 @@ import useDataStore from 'src/store/data';
 // --- Methods and Data ---
 import { BigNumber } from 'src/utils/ethers';
 import { SUPPORTED_TOKENS } from 'src/utils/chains';
-import { pushRoute, formatNumber, isValidAmount, watchTransaction } from 'src/utils/utils';
+import { formatNumber, isValidAmount, metadataId, pushRoute, watchTransaction } from 'src/utils/utils';
 import useWalletStore from 'src/store/wallet';
 
 function useCart() {
@@ -371,7 +371,7 @@ export default defineComponent({
   },
   setup() {
     const NOT_IMPLEMENTED = (msg: string) => window.alert(`NOT IMPLEMENTED: ${msg}`);
-    return { ...useCart(), pushRoute, SUPPORTED_TOKENS, NOT_IMPLEMENTED, formatNumber };
+    return { ...useCart(), pushRoute, SUPPORTED_TOKENS, NOT_IMPLEMENTED, formatNumber, metadataId };
   },
 });
 </script>

--- a/app/src/views/GrantRegistryGrantDetail.vue
+++ b/app/src/views/GrantRegistryGrantDetail.vue
@@ -286,7 +286,19 @@ import useWalletStore from 'src/store/wallet';
 import { LOREM_IPSOM_TEXT } from 'src/utils/constants';
 import { ContractTransaction } from 'src/utils/ethers';
 import { DGRANTS_CHAIN_ID } from 'src/utils/chains';
-import { isValidAddress, isValidWebsite, isValidGithub, isValidTwitter, isValidLogo, isDefined, formatNumber, urlFromTwitterHandle, cleanTwitterUrl, watchTransaction} from 'src/utils/utils'; // prettier-ignore
+import {
+  cleanTwitterUrl,
+  formatNumber,
+  isDefined,
+  isValidAddress,
+  isValidGithub,
+  isValidLogo,
+  isValidTwitter,
+  isValidWebsite,
+  metadataId,
+  urlFromTwitterHandle,
+  watchTransaction,
+} from 'src/utils/utils';
 import * as ipfs from 'src/utils/data/ipfs';
 import { getGrantsGrantRoundDetails } from 'src/utils/data/grantRounds';
 import { filterContributionsByGrantId } from 'src/utils/data/contributions';
@@ -330,7 +342,7 @@ function useGrantDetail() {
     return grants.value[grantId.value];
   });
   const grantId = computed(() => Number(route.params.id));
-  const grantMetadata = computed(() => (grant.value ? metadata.value[grant.value.metaPtr] : null));
+  const grantMetadata = computed(() => (grant.value ? metadata.value[metadataId(grant.value.metaPtr)] : null));
 
   // --- expose Grant/round details ---
   const loading = ref(true);
@@ -590,7 +602,7 @@ function useGrantDetail() {
       const properties = { websiteURI: website, githubURI: github, twitterURI };
       metaPtr = await ipfs
         .uploadGrantMetadata({ name, description, logoURI, properties })
-        .then((cid) => ipfs.getMetaPtr({ cid: cid.toString() }));
+        .then((cid) => ipfs.formatMetaPtr(cid.toString()));
     }
 
     if (owner !== g.owner && payee === g.payee && !isMetaPtrUpdated) {

--- a/app/src/views/GrantRegistryNewGrant.vue
+++ b/app/src/views/GrantRegistryNewGrant.vue
@@ -237,7 +237,7 @@ function useNewGrant() {
     if (!isCorrectNetwork.value) throw new Error('Wrong network');
     const metaPtr = await ipfs
       .uploadGrantMetadata({ name, description, logoURI, properties })
-      .then((cid) => ipfs.getMetaPtr({ cid: cid.toString() }));
+      .then((cid) => ipfs.formatMetaPtr(cid.toString()));
 
     // watch the transaction to check for any replacements/cancellations and update txHash accordingly
     const tx = await watchTransaction(() => grantRegistry.value.createGrant(owner, payee, metaPtr), txHash);

--- a/app/src/views/GrantRound.vue
+++ b/app/src/views/GrantRound.vue
@@ -169,14 +169,15 @@ import useWalletStore from 'src/store/wallet';
 import { GRANT_ROUND_ABI, ERC20_ABI } from 'src/utils/constants';
 import { BigNumber, BigNumberish, Contract, getAddress, MaxUint256, parseUnits } from 'src/utils/ethers';
 import {
+  assertSufficientBalance,
+  checkAllowance,
   daysAgo,
   formatAddress,
-  isValidUrl,
-  checkAllowance,
   getApproval,
   hasStatus,
   isDefined,
-  assertSufficientBalance,
+  isValidUrl,
+  metadataId,
   watchTransaction,
 } from 'src/utils/utils';
 
@@ -276,7 +277,9 @@ function useGrantRoundDetail() {
    * @notice Populate grant round metadata
    */
   const grantRoundMetadata = computed(() =>
-    _grantRoundMetadata.value ? (_grantRoundMetadata.value[grantRound.value?.metaPtr] as GrantRoundMetadata) : null
+    _grantRoundMetadata.value
+      ? (_grantRoundMetadata.value[metadataId(grantRound.value?.metaPtr)] as GrantRoundMetadata)
+      : null
   );
 
   // --- Contribution capabilities ---

--- a/app/src/views/GrantRoundGrants.vue
+++ b/app/src/views/GrantRoundGrants.vue
@@ -27,16 +27,16 @@ import LoadingSpinner from 'src/components/LoadingSpinner.vue';
 import useDataStore from 'src/store/data';
 // --- Methods and Data ---
 import { getAddress } from 'src/utils/ethers';
-import { pushRoute } from 'src/utils/utils';
+import { metadataId, pushRoute } from 'src/utils/utils';
 // --- Types ---
 import { Breadcrumb, FilterNavButton, Grant, GrantRound } from '@dgrants/types';
 
 function useGrantRoundDetail() {
-  const { 
+  const {
     grantRounds,
     grantRoundMetadata: _grantRoundMetadata,
     approvedGrants: allGrants,
-    grantMetadata
+    grantMetadata,
   } = useDataStore();
   const route = useRoute();
 
@@ -67,7 +67,7 @@ function useGrantRoundDetail() {
   });
 
   const grantRoundMetadata = computed(() =>
-    grantRound.value ? _grantRoundMetadata.value[grantRound.value.metaPtr] : null
+    grantRound.value ? _grantRoundMetadata.value[metadataId(grantRound.value.metaPtr)] : null
   );
 
   const title = computed(() => `${grantRoundMetadata.value?.name} Grants`);

--- a/app/src/views/GrantRoundsList.vue
+++ b/app/src/views/GrantRoundsList.vue
@@ -15,9 +15,9 @@
                 :id="index"
                 :ptr="grantRound.metaPtr"
                 :address="grantRound.address"
-                :name="grantRoundMetadata[grantRound.metaPtr].name ?? ''"
-                :imgurl="grantRoundMetadata[grantRound.metaPtr].logoURI ?? '/placeholder_round.svg'"
-                :grantsTotal="grantRoundMetadata[grantRound.metaPtr].grants?.length ?? 0"
+                :name="grantRoundMetadata[metadataId(grantRound.metaPtr)].name ?? ''"
+                :imgurl="grantRoundMetadata[metadataId(grantRound.metaPtr)].logoURI ?? '/placeholder_round.svg'"
+                :grantsTotal="grantRoundMetadata[metadataId(grantRound.metaPtr)].grants?.length ?? 0"
                 :funds="`${formatNumber(grantRound.funds, 2)} ${grantRound.matchingToken.symbol}`"
               />
             </li>
@@ -46,10 +46,11 @@ import {
   daysAgo,
   formatAddress,
   formatNumber,
-  pushRoute,
-  unixToLocaleString,
   hasStatus,
+  metadataId,
+  pushRoute,
   sortByStartTime,
+  unixToLocaleString,
 } from 'src/utils/utils';
 // --- Data and Methods ---
 import useDataStore from 'src/store/data';
@@ -131,6 +132,7 @@ export default defineComponent({
       grantRoundMetadata,
       grantRoundsNav,
       hasStatus,
+      metadataId,
       pushRoute,
       selectedTab,
       unixToLocaleString,

--- a/app/src/views/Home.vue
+++ b/app/src/views/Home.vue
@@ -81,9 +81,9 @@
                 :id="index"
                 :ptr="grantRound.metaPtr"
                 :address="grantRound.address"
-                :name="grantRoundMetadata[grantRound.metaPtr].name ?? ''"
-                :imgurl="grantRoundMetadata[grantRound.metaPtr].logoURI ?? '/placeholder_round.svg'"
-                :grantsTotal="grantRoundMetadata[grantRound.metaPtr].grants?.length ?? 0"
+                :name="grantRoundMetadata[metadataId(grantRound.metaPtr)].name ?? ''"
+                :imgurl="grantRoundMetadata[metadataId(grantRound.metaPtr)].logoURI ?? '/placeholder_round.svg'"
+                :grantsTotal="grantRoundMetadata[metadataId(grantRound.metaPtr)].grants?.length ?? 0"
                 :funds="`${formatNumber(grantRound.funds, 2)} ${grantRound.matchingToken.symbol}`"
               />
             </li>
@@ -158,11 +158,12 @@ import {
   daysAgo,
   formatAddress,
   formatNumber,
-  pushRoute,
-  unixToLocaleString,
   hasStatus,
-  sortByStartTime,
+  metadataId,
+  pushRoute,
   shuffle,
+  sortByStartTime,
+  unixToLocaleString,
 } from 'src/utils/utils';
 // --- Data ---
 import useDataStore from 'src/store/data';
@@ -276,17 +277,18 @@ export default defineComponent({
       daysAgo,
       formatAddress,
       formatNumber,
-      grantRounds,
+      grantContributions,
+      grantMetadata,
       grantRoundLists,
       grantRoundMetadata,
+      grantRounds,
       grantRoundsNav,
+      grants,
       hasStatus,
+      metadataId,
       pushRoute,
       selectedTab,
       unixToLocaleString,
-      grants,
-      grantContributions,
-      grantMetadata,
       validGrantsCount,
       ...useGrantRegistryList(),
     };

--- a/contracts/contracts/GrantRegistry.sol
+++ b/contracts/contracts/GrantRegistry.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.7.6;
 pragma abicoder v2;
 
+import "./interfaces/IMetadataPointer.sol";
+
 /**
  * @notice The Gitcoin GrantRegistry contract keeps track of all grants that have been created.
  * It is designed to be a singleton, i.e. there is only one instance of a GrantRegistry which
@@ -20,7 +22,7 @@ contract GrantRegistry {
     uint96 id; // grant ID, as uint96 to pack into same slot as owner (this implies a max of 2^96-1 = 7.9e28 grants)
     address owner; // grant owner (has permissions to modify grant information)
     address payee; // address that receives funds donated to this grant
-    string metaPtr; // URL pointing to grant metadata (for off-chain use)
+    MetaPtr metaPtr; // metadata pointer
   }
 
   // TODO use an array instead with ID to index it? Which is better?
@@ -30,22 +32,22 @@ contract GrantRegistry {
 
   // --- Events ---
   /// @notice Emitted when a new grant is created
-  event GrantCreated(uint96 indexed id, address indexed owner, address indexed payee, string metaPtr);
+  event GrantCreated(uint96 indexed id, address indexed owner, address indexed payee, MetaPtr metaPtr);
 
   /// @notice Emitted when a grant's owner is changed
-  event GrantUpdated(uint96 indexed id, address indexed owner, address indexed payee, string metaPtr);
+  event GrantUpdated(uint96 indexed id, address indexed owner, address indexed payee, MetaPtr metaPtr);
 
   // --- Core methods ---
   /**
    * @notice Create a new grant in the registry
    * @param _owner Grant owner (has permissions to modify grant information)
    * @param _payee Address that receives funds donated to this grant
-   * @param _metaPtr URL pointing to grant metadata (for off-chain use)
+   * @param _metaPtr metadata pointer
    */
   function createGrant(
     address _owner,
     address _payee,
-    string calldata _metaPtr
+    MetaPtr calldata _metaPtr
   ) external {
     uint96 _id = grantCount;
     grants[_id] = Grant(_id, _owner, _payee, _metaPtr);
@@ -82,7 +84,7 @@ contract GrantRegistry {
    * @param _id ID of grant to update
    * @param _metaPtr New URL that points to grant metadata
    */
-  function updateGrantMetaPtr(uint96 _id, string calldata _metaPtr) external {
+  function updateGrantMetaPtr(uint96 _id, MetaPtr calldata _metaPtr) external {
     Grant storage grant = grants[_id];
     require(msg.sender == grant.owner, "GrantRegistry: Not authorized");
     grant.metaPtr = _metaPtr;
@@ -101,7 +103,7 @@ contract GrantRegistry {
     uint96 _id,
     address _owner,
     address _payee,
-    string calldata _metaPtr
+    MetaPtr calldata _metaPtr
   ) external {
     require(msg.sender == grants[_id].owner, "GrantRegistry: Not authorized");
     grants[_id] = Grant({id: _id, owner: _owner, payee: _payee, metaPtr: _metaPtr});

--- a/contracts/contracts/GrantRound.sol
+++ b/contracts/contracts/GrantRound.sol
@@ -113,7 +113,7 @@ contract GrantRound {
    * @param _newMetaPtr A string where the updated metadata is stored
    */
   function updateMetadataPtr(MetaPtr calldata _newMetaPtr) external {
-    require(msg.sender == metadataAdmin, "GrantRound: Action can be perfomed only by metadataAdmin");
+    require(msg.sender == metadataAdmin, "GrantRound: Action can be performed only by metadataAdmin");
     emit MetadataUpdated(metaPtr, _newMetaPtr);
     metaPtr = _newMetaPtr;
   }

--- a/contracts/contracts/GrantRound.sol
+++ b/contracts/contracts/GrantRound.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.7.6;
+pragma abicoder v2;
 
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "./interfaces/IMetadataPointer.sol";
 import "./GrantRegistry.sol";
 
 contract GrantRound {
@@ -30,14 +32,14 @@ contract GrantRound {
   IERC20 public immutable matchingToken;
 
   /// @notice URL pointing to grant round metadata (for off-chain use)
-  string public metaPtr;
+  MetaPtr public metaPtr;
 
   /// @notice Set to true if grant round has ended and payouts have been released
   bool public hasPaidOut;
 
   // --- Events ---
   /// @notice Emitted when a grant round metadata pointer is updated
-  event MetadataUpdated(string oldMetaPtr, string indexed newMetaPtr);
+  event MetadataUpdated(MetaPtr oldMetaPtr, MetaPtr newMetaPtr);
 
   /// @notice Emitted when a contributor adds funds using the matching pool token
   event AddMatchingFunds(uint256 amount, address indexed contributor);
@@ -65,7 +67,7 @@ contract GrantRound {
     IERC20 _matchingToken,
     uint256 _startTime,
     uint256 _endTime,
-    string memory _metaPtr
+    MetaPtr memory _metaPtr
   ) {
     require(_donationToken.totalSupply() > 0, "GrantRound: Invalid donation token");
     require(_matchingToken.totalSupply() > 0, "GrantRound: Invalid matching token");
@@ -110,7 +112,7 @@ contract GrantRound {
    * @notice Updates the metadata pointer to a new location
    * @param _newMetaPtr A string where the updated metadata is stored
    */
-  function updateMetadataPtr(string calldata _newMetaPtr) external {
+  function updateMetadataPtr(MetaPtr calldata _newMetaPtr) external {
     require(msg.sender == metadataAdmin, "GrantRound: Action can be perfomed only by metadataAdmin");
     emit MetadataUpdated(metaPtr, _newMetaPtr);
     metaPtr = _newMetaPtr;

--- a/contracts/contracts/GrantRoundManager.sol
+++ b/contracts/contracts/GrantRoundManager.sol
@@ -86,7 +86,7 @@ contract GrantRoundManager is SwapRouter {
     IERC20 _matchingToken,
     uint256 _startTime,
     uint256 _endTime,
-    string memory _metaPtr
+    MetaPtr calldata _metaPtr
   ) external {
     require(_matchingToken.totalSupply() > 0, "GrantRoundManager: Invalid matching token");
     GrantRound _grantRound = new GrantRound(

--- a/contracts/contracts/GrantRoundManagerUniV2.sol
+++ b/contracts/contracts/GrantRoundManagerUniV2.sol
@@ -95,7 +95,7 @@ contract GrantRoundManagerUniV2 {
     IERC20 _matchingToken,
     uint256 _startTime,
     uint256 _endTime,
-    string memory _metaPtr
+    MetaPtr calldata _metaPtr
   ) external {
     require(_matchingToken.totalSupply() > 0, "GrantRoundManager: Invalid matching token");
     GrantRound _grantRound = new GrantRound(

--- a/contracts/contracts/interfaces/IMetadataPointer.sol
+++ b/contracts/contracts/interfaces/IMetadataPointer.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.7.6;
 
 struct MetaPtr {
-  uint256 protocol; // mapping from integer to protocol
-  string pointer; // pointer to fetch metadata for the specified protocol
+  // Protocol ID corresponding to a specific protocol. More info at https://github.com/dcgtc/protocol-ids
+  uint256 protocol;
+  // Pointer to fetch metadata for the specified protocol
+  string pointer;
 }

--- a/contracts/contracts/interfaces/IMetadataPointer.sol
+++ b/contracts/contracts/interfaces/IMetadataPointer.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.7.6;
+
+struct MetaPtr {
+  uint256 protocol; // mapping from integer to protocol
+  string pointer; // pointer to fetch metadata for the specified protocol
+}

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@dgrants/contracts",
-  "version": "0.0.27-de1b667.0",
+  "version": "0.1.0-6941e2e.0",
   "devDependencies": {
-    "@dgrants/types": "^0.0.16-de1b667.0",
+    "@dgrants/types": "^0.1.0-6941e2e.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "3.4.1-solc-0.7-2",

--- a/contracts/scripts/app.ts
+++ b/contracts/scripts/app.ts
@@ -19,17 +19,17 @@ const fixtureGrants = async (deployer: SignerWithAddress) => {
     {
       owner: '0x34f4E532a33EB545941e914B25Efe348Aea31f0A',
       payee: '0x06c94663E5884BE4cCe85F0869e95C7712d34803',
-      metaPtr: 'https://ipfs.fleek.co/ipfs/QmaHTgor7GhetW3nmev3UqabjrzbKJCe7q1v8Wfg3aZyV4',
+      metaPtr: { protocol: 1, pointer: 'QmaHTgor7GhetW3nmev3UqabjrzbKJCe7q1v8Wfg3aZyV4' },
     },
     {
       owner: '0x58E52440F56f2A5307772Ec881BCEf2c15e988Ab',
       payee: '0x6f02c37ea174DD05f20aC118da725ffa6A40B990',
-      metaPtr: 'https://ipfs.fleek.co/ipfs/Qma9gnPTmdZ65UVjJd9nkM6S8etti8qtNBD1ta6vVpSSVS',
+      metaPtr: { protocol: 1, pointer: 'Qma9gnPTmdZ65UVjJd9nkM6S8etti8qtNBD1ta6vVpSSVS' },
     },
     {
       owner: '0x1fB6C46e6aDD95698352707D7f93a31030c80a0B',
       payee: '0x834e659c6757E250db500fe869877311Bb552966',
-      metaPtr: 'https://ipfs.fleek.co/ipfs/QmTQMgoxDRj8gfNn5Cvznt5CoEE6cz9MQeZrQsNb36BMdm',
+      metaPtr: { protocol: 1, pointer: 'QmTQMgoxDRj8gfNn5Cvznt5CoEE6cz9MQeZrQsNb36BMdm' },
     },
   ];
 
@@ -67,7 +67,7 @@ const fixtureRound = async (registry: Contract, manager: Contract) => {
   const metadataAdmin = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
   const payoutAdmin = '0x06c94663E5884BE4cCe85F0869e95C7712d34803';
   const matchingToken = tokens.dai.address;
-  const metaPtr = 'https://ipfs.fleek.co/ipfs/bafybeib5r75zbrzavbskwywct42alawcwo7d4dlyipimvnjy23hfkqhham';
+  const metaPtr = { protocol: 1, pointer: 'bafybeib5r75zbrzavbskwywct42alawcwo7d4dlyipimvnjy23hfkqhham' };
 
   const tx = await manager.createGrantRound(
     metadataAdmin,

--- a/contracts/test/GrantRound.test.ts
+++ b/contracts/test/GrantRound.test.ts
@@ -178,7 +178,7 @@ describe('GrantRound', function () {
     it('reverts if not the grant round metadata admin', async function () {
       const { roundContract } = await loadFixture(setup);
       await expect(roundContract.connect(mpUser).updateMetadataPtr({ protocol: 1, pointer: 'x' })).to.be.revertedWith(
-        'GrantRound: Action can be perfomed only by metadataAdmin'
+        'GrantRound: Action can be performed only by metadataAdmin'
       );
     });
   });

--- a/contracts/test/GrantRound.test.ts
+++ b/contracts/test/GrantRound.test.ts
@@ -17,7 +17,7 @@ const { MaxUint256 } = ethers.constants;
 const { isAddress } = ethers.utils;
 
 describe('GrantRound', function () {
-  const mockUrl: string = 'https://test.url';
+  const mockMetaPtr = { protocol: 1, pointer: 'QmPMERYmqZtbHmqd2UzRhX9F4cixnMQU2GFa2hYAsQ6J3D' }; // dummy data
   let deployer: SignerWithAddress,
     payoutAdmin: SignerWithAddress,
     donor: SignerWithAddress,
@@ -50,7 +50,7 @@ describe('GrantRound', function () {
     registry = <GrantRegistry>await deployContract(deployer, grantRegistryArtifact);
 
     // Create an example grant
-    await registry.connect(deployer).createGrant(deployer.address, grantPayee.address, mockUrl);
+    await registry.connect(deployer).createGrant(deployer.address, grantPayee.address, mockMetaPtr);
 
     const grantRoundArtifact: Artifact = await artifacts.readArtifact('GrantRound');
     roundContractFactory = new ethers.ContractFactory(grantRoundArtifact.abi, grantRoundArtifact.bytecode, deployer);
@@ -66,7 +66,7 @@ describe('GrantRound', function () {
       mockMatchingERC20.address,
       startTime,
       endTime,
-      mockUrl
+      mockMetaPtr
     );
 
     return { mockMatchingERC20, mockDonationERC20, roundContract };
@@ -138,7 +138,7 @@ describe('GrantRound', function () {
           mockERC20.address,
           startTime,
           endTime,
-          mockUrl
+          mockMetaPtr
         )
       ).to.be.reverted;
     });
@@ -167,17 +167,17 @@ describe('GrantRound', function () {
   describe('updateMetadataPtr - updates metadata pointer string', () => {
     it('updates the pointer and emits an event', async function () {
       const { roundContract } = await loadFixture(setup);
-      const newPtr = 'https://new.com';
+      const newPtr = { protocol: 1, pointer: 'QmPMERYmqZtbHmqd2UzRhX9F4cixnMQU2GFa2hYAsQ6J3D' }; // dummy data
       const oldPtr = await roundContract.metaPtr();
 
       await expect(roundContract.connect(deployer).updateMetadataPtr(newPtr))
         .to.emit(roundContract, 'MetadataUpdated')
-        .withArgs(oldPtr, newPtr);
+        .withArgs([oldPtr.protocol, oldPtr.pointer], [newPtr.protocol, oldPtr.pointer]);
     });
 
     it('reverts if not the grant round metadata admin', async function () {
       const { roundContract } = await loadFixture(setup);
-      await expect(roundContract.connect(mpUser).updateMetadataPtr('test')).to.be.revertedWith(
+      await expect(roundContract.connect(mpUser).updateMetadataPtr({ protocol: 1, pointer: 'x' })).to.be.revertedWith(
         'GrantRound: Action can be perfomed only by metadataAdmin'
       );
     });

--- a/contracts/test/GrantRoundManager.test.ts
+++ b/contracts/test/GrantRoundManager.test.ts
@@ -93,7 +93,7 @@ describe('GrantRoundManager', () => {
     const payoutAdmin = randomAddress();
     const startTime = '50000000000000'; // random timestamp far in the future
     const endTime = '60000000000000'; // random timestamp far in the future
-    const metaPtr = 'https://metadata-pointer.com';
+    const metaPtr = { protocol: 1, pointer: 'QmPMERYmqZtbHmqd2UzRhX9F4cixnMQU2GFa2hYAsQ6J3D' }; // dummy data
 
     beforeEach(async () => {
       mockMatchingToken = await deployMockContract(user, ['function totalSupply() returns(uint256)']);
@@ -127,7 +127,10 @@ describe('GrantRoundManager', () => {
       expect(await grantRound.matchingToken()).to.equal(mockMatchingToken.address);
       expect(await grantRound.startTime()).to.equal(startTime);
       expect(await grantRound.endTime()).to.equal(endTime);
-      expect(await grantRound.metaPtr()).to.equal(metaPtr);
+
+      const newMetaPtr = await grantRound.metaPtr();
+      expect(newMetaPtr.protocol).to.equal(metaPtr.protocol);
+      expect(newMetaPtr.pointer).to.equal(metaPtr.pointer);
     });
 
     it('reverts when creating a round with an invalid matching token', async () => {

--- a/contracts/test/__snapshots__/gas.test.ts.snap
+++ b/contracts/test/__snapshots__/gas.test.ts.snap
@@ -1,25 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`dGrants gas tests GrantRegistry createGrant 1`] = `166397`;
+exports[`dGrants gas tests GrantRegistry createGrant 1`] = `166893`;
 
-exports[`dGrants gas tests GrantRegistry updateGrantMetaPtr 1`] = `49773`;
+exports[`dGrants gas tests GrantRegistry updateGrantMetaPtr 1`] = `47173`;
 
-exports[`dGrants gas tests GrantRegistry updateGrantMetaPtr 2`] = `56298`;
+exports[`dGrants gas tests GrantRegistry updateGrantMetaPtr 2`] = `53975`;
 
-exports[`dGrants gas tests GrantRegistry updateGrantOwner 1`] = `41611`;
+exports[`dGrants gas tests GrantRegistry updateGrantOwner 1`] = `41856`;
 
-exports[`dGrants gas tests GrantRegistry updateGrantPayee 1`] = `41614`;
+exports[`dGrants gas tests GrantRegistry updateGrantPayee 1`] = `41860`;
 
-exports[`dGrants gas tests GrantRoundManager createGrantRound 1`] = `892431`;
+exports[`dGrants gas tests GrantRoundManager createGrantRound 1`] = `983308`;
 
-exports[`dGrants gas tests GrantRoundManager five donations input token DAI, output token DAI 1`] = `226976`;
+exports[`dGrants gas tests GrantRoundManager five donations input token DAI, output token DAI 1`] = `227236`;
 
-exports[`dGrants gas tests GrantRoundManager five donations input token ETH, output token DAI 1`] = `324016`;
+exports[`dGrants gas tests GrantRoundManager five donations input token ETH, output token DAI 1`] = `324236`;
 
-exports[`dGrants gas tests GrantRoundManager five donations input token GTC, output token DAI 1`] = `390363`;
+exports[`dGrants gas tests GrantRoundManager five donations input token GTC, output token DAI 1`] = `390543`;
 
-exports[`dGrants gas tests GrantRoundManager one donation input token DAI, output token DAI 1`] = `91395`;
+exports[`dGrants gas tests GrantRoundManager one donation input token DAI, output token DAI 1`] = `91436`;
 
-exports[`dGrants gas tests GrantRoundManager one donation input token ETH, output token DAI 1`] = `185288`;
+exports[`dGrants gas tests GrantRoundManager one donation input token ETH, output token DAI 1`] = `185298`;
 
-exports[`dGrants gas tests GrantRoundManager one donation input token GTC, output token DAI 1`] = `238361`;
+exports[`dGrants gas tests GrantRoundManager one donation input token GTC, output token DAI 1`] = `238339`;

--- a/contracts/test/gas.test.ts
+++ b/contracts/test/gas.test.ts
@@ -17,8 +17,8 @@ const { parseUnits } = ethers.utils;
 const { deployContract, loadFixture } = waffle;
 const addr1 = '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'; // hardhat account 0, but can be any address
 const addr2 = '0x70997970c51812dc3a010c7d01b50e0d17dc79c8'; // hardhat account 1, but can be any address
-const metaPtr1 = 'https://ipfs.fleek.co/ipfs/QmaHTgor7GhetW3nmev3UqabjrzbKJCe7q1v8Wfg3aZyV4';
-const metaPtr2 = 'https://ipfs.fleek.co/ipfs/QmeqiDZMA41ekPV9BJDx3VGtJbxU34YSS3oorLA8cPuib6';
+const metaPtr1 = { protocol: 1, pointer: 'QmaHTgor7GhetW3nmev3UqabjrzbKJCe7q1v8Wfg3aZyV4' };
+const metaPtr2 = { protocol: 1, pointer: 'QmeqiDZMA41ekPV9BJDx3VGtJbxU34YSS3oorLA8cPuib6' };
 
 // --- Gas tests ---
 describe('dGrants gas tests', () => {

--- a/contracts/test/polygon/GrantRoundManagerUniV2.test.ts
+++ b/contracts/test/polygon/GrantRoundManagerUniV2.test.ts
@@ -89,7 +89,7 @@ describe('GrantRoundManagerUniV2', () => {
     const payoutAdmin = randomAddress();
     const startTime = '50000000000000'; // random timestamp far in the future
     const endTime = '60000000000000'; // random timestamp far in the future
-    const metaPtr = 'https://metadata-pointer.com';
+    const metaPtr = { protocol: 1, pointer: 'QmPMERYmqZtbHmqd2UzRhX9F4cixnMQU2GFa2hYAsQ6J3D' }; // dummy data
 
     beforeEach(async () => {
       mockMatchingToken = await deployMockContract(user, ['function totalSupply() returns(uint256)']);
@@ -123,7 +123,10 @@ describe('GrantRoundManagerUniV2', () => {
       expect(await grantRound.matchingToken()).to.equal(mockMatchingToken.address);
       expect(await grantRound.startTime()).to.equal(startTime);
       expect(await grantRound.endTime()).to.equal(endTime);
-      expect(await grantRound.metaPtr()).to.equal(metaPtr);
+
+      const roundMetaPtr = await grantRound.metaPtr();
+      expect(roundMetaPtr.protocol).to.equal(metaPtr.protocol);
+      expect(roundMetaPtr.pointer).to.equal(metaPtr.pointer);
     });
 
     it('reverts when creating a round with an invalid matching token', async () => {

--- a/contracts/test/utils.ts
+++ b/contracts/test/utils.ts
@@ -46,7 +46,8 @@ export function expectEqualGrants(grant1: GrantEthers, grant2: GrantEthers): voi
   expect(grant1.id).to.equal(grant2.id);
   expect(grant1.owner).to.equal(grant2.owner);
   expect(grant1.payee).to.equal(grant2.payee);
-  expect(grant1.metaPtr).to.equal(grant2.metaPtr);
+  expect(grant1.metaPtr.protocol).to.equal(grant2.metaPtr.protocol);
+  expect(grant1.metaPtr.pointer).to.equal(grant2.metaPtr.pointer);
 }
 
 // --- Time manipulation ---

--- a/dcurve/package.json
+++ b/dcurve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/dcurve",
-  "version": "0.0.27-de1b667.0",
+  "version": "0.1.0-6941e2e.0",
   "private": true,
   "description": "distribution generator for GrantCLR in dgrants",
   "keywords": [
@@ -29,8 +29,8 @@
     "extends": "../package.json"
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.0.27-de1b667.0",
-    "@dgrants/utils": "^0.0.16-de1b667.0",
+    "@dgrants/contracts": "^0.1.0-6941e2e.0",
+    "@dgrants/utils": "^0.1.0-6941e2e.0",
     "buffer": "^6.0.3",
     "ethers": "^5.4.6"
   },

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/types",
-  "version": "0.0.16-de1b667.0",
+  "version": "0.1.0-6941e2e.0",
   "types": "src/index.d.ts",
   "scripts": {
     "build": "tsc -b .",

--- a/types/src/grantRounds.d.ts
+++ b/types/src/grantRounds.d.ts
@@ -1,6 +1,6 @@
 import { BigNumberish } from 'ethers';
 import { TokenInfo } from '@uniswap/token-lists';
-import { Contribution, GrantPrediction } from './grants';
+import { Contribution, GrantPrediction, MetaPtr } from './grants';
 
 /**
  * Data types for entity being pulled from the subgraph
@@ -28,7 +28,7 @@ export type GrantRoundSubgraph = {
  * @field {status} The current status of the round (Active|Upcoming|Complete)
  * @field {startTime} The start time of the round (unix)
  * @field {endTime} The end time of the round (unix)
- * @field {metaPtr} The ipfs metaPtr associated with the round
+ * @field {metaPtr} The metaPtr associated with the round
  * @field {hasPaidOut} Marked when the round matching has been paid out
  * @field {error} Optional error string
  */
@@ -43,7 +43,7 @@ export type GrantRound = {
   status: string;
   startTime: BigNumberish;
   endTime: BigNumberish;
-  metaPtr: string;
+  metaPtr: MetaPtr;
   hasPaidOut: boolean;
   error: string | undefined;
 };

--- a/types/src/grants.d.ts
+++ b/types/src/grants.d.ts
@@ -4,12 +4,14 @@ import { TokenInfo } from '@uniswap/token-lists';
 // --- Grants ---
 // The output from ethers/typechain allows array or object access to grant data, so we must define types for
 // handling the Grant struct as done below
+export type MetaPtr = { protocol: BigNumberish; pointer: string };
+
 export type GrantEthersArray = [BigNumber, string, string, string];
 export type GrantEthersObject = {
   id: BigNumber;
   owner: string;
   payee: string;
-  metaPtr: string;
+  metaPtr: MetaPtr;
 };
 export type GrantEthers = GrantEthersObject | (GrantEthersArray & GrantEthersObject);
 // When pulled from the subgraph a grant will have the following properties
@@ -17,7 +19,7 @@ export type GrantSubgraph = {
   id: BigNumberish;
   owner: string;
   payee: string;
-  metaPtr: string;
+  metaPtr: MetaPtr;
   lastUpdatedBlockNumber: number;
 };
 // internally we cast id:BigNumber from GrantEthers to a number for Grant
@@ -25,7 +27,7 @@ export type Grant = {
   id: number;
   owner: string;
   payee: string;
-  metaPtr: string;
+  metaPtr: MetaPtr;
 };
 
 // Metadata resolve from a grant's metadata pointer URL
@@ -141,7 +143,7 @@ export type GrantPrediction = {
  */
 export type GrantsRoundDetails = {
   address: string;
-  metaPtr: string;
+  metaPtr: MetaPtr;
   name: string;
   matchingToken: TokenInfo;
   donationToken: TokenInfo;

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/utils",
-  "version": "0.0.16-de1b667.0",
+  "version": "0.1.0-6941e2e.0",
   "description": "common methods shared",
   "keywords": [
     "dgrants",


### PR DESCRIPTION
Closes #481 

This description first contains details about the fact that this PR is a breaking change, then details on the changes are given. Lastly, there are some open questions we should answer before merging this PR

## WARNING

**This PR is a MAJOR breaking change because it changes the keys used to cache data locally**. As a result:
1. You will need to clear all site data
2. Once this PR is merged, you will only be able to dev/test with `VITE_DGRANTS_CHAIN_ID=31337` which runs the app against Hardhat. This is required because no contracts with this new `MetaPtr` format are deployed to Rinkeby or Polygon
3. To test sending transactions, you'll need to set MetaMask to use one of the default Hardhat accounts (reminder that instructions on how to do this can be found [here](https://github.com/dcgtc/dgrants/tree/main/app#setup))

## Details 

The contracts now use a struct to define the metadata pointer. This is defined in `contracts/contracts/interfaces/IMetadataPointer.sol` as follows:

```solidity
struct MetaPtr {
  uint256 protocol; // mapping from integer to protocol, currently only a value of 1 representing IPFS is supported
  string pointer; // pointer to fetch metadata for the specified protocol
}
```

To account for this on the frontend, we had to make some changes:
- A new method called `metadataId()` was added which takes in the above struct and generates a string from the data. That string can be used in place of the original `metaPtr` string type that was used to index into objects
- The inverse of this is a method called `decodeMetadataId`, which takes in the string and returns the original object

## Questions / TODO before merging

- [x] 1. @phutchins Can I create a `dcgtc/protocol-ids` repo to track the mapping from `protocol` integers to protocol names? The repo will be a standalone repo with a single README.md file that looks very similar to [this file](https://github.com/satoshilabs/slips/blob/master/slip-0044.md), i.e. it will be a simple table and anyone can submit a PR to add a new mapping from integer to protocol
- [x] 2. Given that this PR is a breaking change, do we want to use `bump:minor` instead of the usual `yarn bump:patch` before merging? Normally this would be `yarn bump:major` but I don't think we want to have a v1.0.0 just yet
- [x] 3. We'll want to bump the `version` specified in `app/src/utils/constants.ts`. I haven't done this yet because I know @gdixon is also bumping it in #493 so we'll need to both adjust the version accordingly depending on which gets merged first