### PR TITLE
fix: reduce configured blockLimit to match RPCs blockLimit

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/app",
-  "version": "0.2.5-a746c51.0",
+  "version": "0.2.6-b2b9f5d.0",
   "private": true,
   "scripts": {
     "clean": "rimraf dist",
@@ -14,9 +14,9 @@
     "prettier": "prettier --write ."
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.2.5-a746c51.0",
-    "@dgrants/dcurve": "^0.2.5-a746c51.0",
-    "@dgrants/types": "^0.2.5-a746c51.0",
+    "@dgrants/contracts": "^0.2.6-b2b9f5d.0",
+    "@dgrants/dcurve": "^0.2.6-b2b9f5d.0",
+    "@dgrants/types": "^0.2.6-b2b9f5d.0",
     "@fusion-icons/vue": "^0.0.0",
     "@headlessui/vue": "^1.2.0",
     "@tailwindcss/aspect-ratio": "^0.2.1",

--- a/app/src/utils/chains.ts
+++ b/app/src/utils/chains.ts
@@ -176,7 +176,7 @@ export const ALL_CHAIN_INFO: ChainInfo = {
     rpcUrl: 'https://polygon-rpc.com/',
     subgraphUrl: false,
     startBlock: 21463653,
-    filterBlockLimit: 25000,
+    filterBlockLimit: 10000,
   },
   [SupportedChainId.RINKEBY]: {
     explorer: 'https://rinkeby.etherscan.io',

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@dgrants/contracts",
-  "version": "0.2.5-a746c51.0",
+  "version": "0.2.6-b2b9f5d.0",
   "devDependencies": {
-    "@dgrants/types": "^0.2.5-a746c51.0",
+    "@dgrants/types": "^0.2.6-b2b9f5d.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "3.4.1-solc-0.7-2",

--- a/dcurve/package.json
+++ b/dcurve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/dcurve",
-  "version": "0.2.5-a746c51.0",
+  "version": "0.2.6-b2b9f5d.0",
   "private": true,
   "description": "distribution generator for GrantCLR in dgrants",
   "keywords": [
@@ -29,8 +29,8 @@
     "extends": "../package.json"
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.2.5-a746c51.0",
-    "@dgrants/utils": "^0.2.5-a746c51.0",
+    "@dgrants/contracts": "^0.2.6-b2b9f5d.0",
+    "@dgrants/utils": "^0.2.6-b2b9f5d.0",
     "buffer": "^6.0.3",
     "ethers": "^5.4.6"
   },

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/types",
-  "version": "0.2.5-a746c51.0",
+  "version": "0.2.6-b2b9f5d.0",
   "types": "src/index.d.ts",
   "scripts": {
     "build": "tsc -b .",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/utils",
-  "version": "0.2.5-a746c51.0",
+  "version": "0.2.6-b2b9f5d.0",
   "description": "common methods shared",
   "keywords": [
     "dgrants",


### PR DESCRIPTION
This PR will reduce the `blockLimit` we have configured against polygon to match the `blockLimit` that the RPC endpoint is willing to accept.

--

Tested locally and this will allow staging to load.