### PR TITLE
use default provider for fetch

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/app",
-  "version": "0.2.8-ad0866d.0",
+  "version": "0.2.9-9061a2e.0",
   "private": true,
   "scripts": {
     "clean": "rimraf dist",

--- a/app/src/components/TransactionStatus.vue
+++ b/app/src/components/TransactionStatus.vue
@@ -50,7 +50,7 @@
 <script lang="ts">
 import { computed, defineComponent, Ref, ref, SetupContext, watch } from 'vue';
 import { getEtherscanUrl } from 'src/utils/utils';
-import useWalletStore from 'src/store/wallet';
+import { DEFAULT_PROVIDER } from 'src/utils/chains';
 
 const emittedEventName = 'onReceipt'; // emitted once we receive the transaction receipt
 
@@ -78,12 +78,11 @@ function useTransactionStatus(hash: Ref, context: SetupContext<'onReceipt'[]>) {
   const etherscanUrl = computed(() => getEtherscanUrl(hash.value));
 
   // watch for new tx hashes then fetch receipt and wait for it to be mined, finally emit event with receipt status once mined
-  const { default_provider } = useWalletStore();
   // if the props.hash changes then we need to await the new tx
   watch(
     () => hash.value,
     async () => {
-      const receipt = await default_provider.value.waitForTransaction(hash.value);
+      const receipt = await DEFAULT_PROVIDER.waitForTransaction(hash.value);
       status.value = receipt.status === 1 ? 'success' : 'failed';
       emitTxReceipt(Boolean(receipt.status));
     },

--- a/app/src/components/TransactionStatus.vue
+++ b/app/src/components/TransactionStatus.vue
@@ -78,12 +78,12 @@ function useTransactionStatus(hash: Ref, context: SetupContext<'onReceipt'[]>) {
   const etherscanUrl = computed(() => getEtherscanUrl(hash.value));
 
   // watch for new tx hashes then fetch receipt and wait for it to be mined, finally emit event with receipt status once mined
-  const { provider } = useWalletStore();
+  const { default_provider } = useWalletStore();
   // if the props.hash changes then we need to await the new tx
   watch(
     () => hash.value,
     async () => {
-      const receipt = await provider.value.waitForTransaction(hash.value);
+      const receipt = await default_provider.value.waitForTransaction(hash.value);
       status.value = receipt.status === 1 ? 'success' : 'failed';
       emitTxReceipt(Boolean(receipt.status));
     },

--- a/app/src/store/cart.ts
+++ b/app/src/store/cart.ts
@@ -8,7 +8,13 @@
 import { computed, ref } from 'vue';
 import { Donation, Grant, SwapSummary, SwapSummaryUniV2 } from '@dgrants/types';
 import { CartItem, CartItemOptions, CartPrediction, CartPredictions } from 'src/types';
-import { SupportedChainId, SUPPORTED_TOKENS, SUPPORTED_TOKENS_MAPPING, WETH_ADDRESS } from 'src/utils/chains';
+import {
+  DEFAULT_PROVIDER,
+  SupportedChainId,
+  SUPPORTED_TOKENS,
+  SUPPORTED_TOKENS_MAPPING,
+  WETH_ADDRESS,
+} from 'src/utils/chains';
 import { ERC20_ABI, ETH_ADDRESS, WAD } from 'src/utils/constants';
 import { BigNumber, BigNumberish, BytesLike, Contract, ContractTransaction, formatUnits, getAddress, hexDataSlice, isAddress, MaxUint256, parseUnits } from 'src/utils/ethers'; // prettier-ignore
 import { assertSufficientBalance, metadataId } from 'src/utils/utils';
@@ -535,18 +541,17 @@ function fixDonationRoundingErrors(donations: Donation[]) {
  * @param amountIn Swap input amount, as a full integer
  */
 async function quoteExactInput(path: BytesLike | string[], amountIn: BigNumberish): Promise<BigNumber> {
-  const { provider } = useWalletStore();
   let amountOut: BigNumber;
   if (Array.isArray(path)) {
     // Polygon mainnet, Uniswap V2 format
     const abi = ['function getAmountsOut(uint amountIn, address[] calldata path) external view returns (uint[] memory amounts)']; // prettier-ignore
-    const router = new Contract('0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506', abi, provider.value); // TODO hardcoded Polygon mainnet SushiSwap address
+    const router = new Contract('0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506', abi, DEFAULT_PROVIDER); // TODO hardcoded Polygon mainnet SushiSwap address
     const amountsOut = await router.getAmountsOut(amountIn, path);
     amountOut = amountsOut[amountsOut.length - 1];
   } else {
     // L1 mainnet, Uniswap V3 format
     const abi = ['function quoteExactInput(bytes memory path, uint256 amountIn) external view returns (uint256 amountOut)']; // prettier-ignore
-    const quoter = new Contract('0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6', abi, provider.value); // TODO hardcoded L1 mainnet Uniswap V3 address
+    const quoter = new Contract('0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6', abi, DEFAULT_PROVIDER); // TODO hardcoded L1 mainnet Uniswap V3 address
     amountOut = await quoter.quoteExactInput(path, amountIn);
   }
   return amountOut.mul(995).div(1000); // multiplying by 995/1000 is equivalent to 0.5% slippage

--- a/app/src/store/data.ts
+++ b/app/src/store/data.ts
@@ -32,7 +32,7 @@ import {
   GRANT_REGISTRY_ADDRESS,
   GRANT_ROUND_MANAGER_ADDRESS,
   SUPPORTED_TOKENS_MAPPING,
-  // DEFAULT_PROVIDER,
+  DEFAULT_PROVIDER,
   DGRANTS_CHAIN_ID,
 } from 'src/utils/chains';
 import { DefaultStorage, getStorageKey, setStorageKey } from 'src/utils/data/utils';
@@ -40,7 +40,7 @@ import { GRANT_ROUND_ABI, ERC20_ABI } from 'src/utils/constants';
 import { metadataId } from 'src/utils/utils';
 
 // --- Parameters required ---
-const { default_provider, grantRoundManager, network } = useWalletStore();
+const { grantRoundManager, network } = useWalletStore();
 
 // --- State ---
 // Most recent data read is saved as state
@@ -84,8 +84,8 @@ export default function useDataStore() {
   async function rawInit(forceRefresh = false) {
     // Check contracts are available on the given provider (or default provider)
     const [isGrantRegistryDeployed, isGrantRoundManagerDeployed] = await Promise.all([
-      (await default_provider.value.getCode(GRANT_REGISTRY_ADDRESS)) !== '0x',
-      (await default_provider.value.getCode(GRANT_ROUND_MANAGER_ADDRESS)) !== '0x',
+      (await DEFAULT_PROVIDER.getCode(GRANT_REGISTRY_ADDRESS)) !== '0x',
+      (await DEFAULT_PROVIDER.getCode(GRANT_ROUND_MANAGER_ADDRESS)) !== '0x',
     ]);
 
     // This ensures we're only attempting to load data from contracts which exist
@@ -97,7 +97,7 @@ export default function useDataStore() {
     await removeAllListeners();
 
     // Get blockdata
-    lastBlockNumber.value = BigNumber.from(await default_provider.value.getBlockNumber()).toNumber();
+    lastBlockNumber.value = BigNumber.from(await DEFAULT_PROVIDER.getBlockNumber()).toNumber();
 
     // Get all grants and round data held in the registry/roundManager
     const [grantsData, grantRoundData, grantRoundDonationTokenAddress] = await Promise.all([
@@ -210,13 +210,9 @@ export default function useDataStore() {
     // Set up watchers on the grantRounds
     grantRoundsList.forEach(async (grantRound) => {
       // open the rounds contract
-      const roundContract = new Contract(grantRound.address, GRANT_ROUND_ABI, default_provider.value);
+      const roundContract = new Contract(grantRound.address, GRANT_ROUND_ABI, DEFAULT_PROVIDER);
       // open the rounds contract
-      const matchingTokenContract = new Contract(
-        await roundContract.matchingToken(),
-        ERC20_ABI,
-        default_provider.value
-      );
+      const matchingTokenContract = new Contract(await roundContract.matchingToken(), ERC20_ABI, DEFAULT_PROVIDER);
       // attach listeners to the rounds
       listeners.value.push(
         metadataUpdatedListener(
@@ -317,8 +313,7 @@ export default function useDataStore() {
    */
   async function startPolling() {
     // clear old wallet connections
-    default_provider.value.removeAllListeners(); // provider used when wallet is connected
-    // DEFAULT_PROVIDER.removeAllListeners(); // provider used when no wallet is connected
+    DEFAULT_PROVIDER.removeAllListeners();
 
     // record the network value to detect changes
     const networkValue = (await getStorageKey('network'))?.data || network.value;

--- a/app/src/store/data.ts
+++ b/app/src/store/data.ts
@@ -32,7 +32,7 @@ import {
   GRANT_REGISTRY_ADDRESS,
   GRANT_ROUND_MANAGER_ADDRESS,
   SUPPORTED_TOKENS_MAPPING,
-  DEFAULT_PROVIDER,
+  // DEFAULT_PROVIDER,
   DGRANTS_CHAIN_ID,
 } from 'src/utils/chains';
 import { DefaultStorage, getStorageKey, setStorageKey } from 'src/utils/data/utils';
@@ -40,7 +40,7 @@ import { GRANT_ROUND_ABI, ERC20_ABI } from 'src/utils/constants';
 import { metadataId } from 'src/utils/utils';
 
 // --- Parameters required ---
-const { provider, grantRoundManager, network } = useWalletStore();
+const { default_provider, grantRoundManager, network } = useWalletStore();
 
 // --- State ---
 // Most recent data read is saved as state
@@ -84,8 +84,8 @@ export default function useDataStore() {
   async function rawInit(forceRefresh = false) {
     // Check contracts are available on the given provider (or default provider)
     const [isGrantRegistryDeployed, isGrantRoundManagerDeployed] = await Promise.all([
-      (await provider.value.getCode(GRANT_REGISTRY_ADDRESS)) !== '0x',
-      (await provider.value.getCode(GRANT_ROUND_MANAGER_ADDRESS)) !== '0x',
+      (await default_provider.value.getCode(GRANT_REGISTRY_ADDRESS)) !== '0x',
+      (await default_provider.value.getCode(GRANT_ROUND_MANAGER_ADDRESS)) !== '0x',
     ]);
 
     // This ensures we're only attempting to load data from contracts which exist
@@ -97,7 +97,7 @@ export default function useDataStore() {
     await removeAllListeners();
 
     // Get blockdata
-    lastBlockNumber.value = BigNumber.from(await provider.value.getBlockNumber()).toNumber();
+    lastBlockNumber.value = BigNumber.from(await default_provider.value.getBlockNumber()).toNumber();
 
     // Get all grants and round data held in the registry/roundManager
     const [grantsData, grantRoundData, grantRoundDonationTokenAddress] = await Promise.all([
@@ -210,9 +210,13 @@ export default function useDataStore() {
     // Set up watchers on the grantRounds
     grantRoundsList.forEach(async (grantRound) => {
       // open the rounds contract
-      const roundContract = new Contract(grantRound.address, GRANT_ROUND_ABI, provider.value);
+      const roundContract = new Contract(grantRound.address, GRANT_ROUND_ABI, default_provider.value);
       // open the rounds contract
-      const matchingTokenContract = new Contract(await roundContract.matchingToken(), ERC20_ABI, provider.value);
+      const matchingTokenContract = new Contract(
+        await roundContract.matchingToken(),
+        ERC20_ABI,
+        default_provider.value
+      );
       // attach listeners to the rounds
       listeners.value.push(
         metadataUpdatedListener(
@@ -313,8 +317,9 @@ export default function useDataStore() {
    */
   async function startPolling() {
     // clear old wallet connections
-    provider.value.removeAllListeners(); // provider used when wallet is connected
-    DEFAULT_PROVIDER.removeAllListeners(); // provider used when no wallet is connected
+    default_provider.value.removeAllListeners(); // provider used when wallet is connected
+    // DEFAULT_PROVIDER.removeAllListeners(); // provider used when no wallet is connected
+
     // record the network value to detect changes
     const networkValue = (await getStorageKey('network'))?.data || network.value;
     // watch the network

--- a/app/src/store/wallet.ts
+++ b/app/src/store/wallet.ts
@@ -41,7 +41,6 @@ let onboard: OnboardAPI; // instance of Blocknative's onboard.js library
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const rawProvider = ref<any>(); // raw provider from the user's wallet, e.g. EIP-1193 provider
 const provider = ref<Web3Provider | JsonRpcProvider>(markRaw(DEFAULT_PROVIDER)); // ethers provider
-const default_provider = ref<Web3Provider | JsonRpcProvider>(markRaw(DEFAULT_PROVIDER));
 const signer = ref<JsonRpcSigner>(); // ethers signer
 const userAddress = ref<string>(); // user's wallet address
 const userEns = ref<string | null>(); // user's ENS name
@@ -255,7 +254,6 @@ export default function useWalletStore() {
     multicall,
     network: computed(() => network.value),
     provider: computed(() => provider.value),
-    default_provider: computed(() => default_provider.value),
     signer: computed(() => signer.value),
     userAddress: computed(() => userAddress.value),
     userDisplayName: computed(() => userEns.value || formatAddress(userAddress.value || '')),

--- a/app/src/store/wallet.ts
+++ b/app/src/store/wallet.ts
@@ -41,6 +41,7 @@ let onboard: OnboardAPI; // instance of Blocknative's onboard.js library
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const rawProvider = ref<any>(); // raw provider from the user's wallet, e.g. EIP-1193 provider
 const provider = ref<Web3Provider | JsonRpcProvider>(markRaw(DEFAULT_PROVIDER)); // ethers provider
+const default_provider = ref<Web3Provider | JsonRpcProvider>(markRaw(DEFAULT_PROVIDER));
 const signer = ref<JsonRpcSigner>(); // ethers signer
 const userAddress = ref<string>(); // user's wallet address
 const userEns = ref<string | null>(); // user's ENS name
@@ -254,6 +255,7 @@ export default function useWalletStore() {
     multicall,
     network: computed(() => network.value),
     provider: computed(() => provider.value),
+    default_provider: computed(() => default_provider.value),
     signer: computed(() => signer.value),
     userAddress: computed(() => userAddress.value),
     userDisplayName: computed(() => userEns.value || formatAddress(userAddress.value || '')),

--- a/app/src/utils/data/contributions.ts
+++ b/app/src/utils/data/contributions.ts
@@ -9,7 +9,7 @@ import { BigNumber, BigNumberish, Event, EventFilter } from 'ethers';
 import { syncStorage } from 'src/utils/data/utils';
 // --- Constants ---
 import { contributionsKey, trustBonusKey } from 'src/utils/constants';
-import { GRANT_ROUND_MANAGER_ADDRESS, START_BLOCK, SUBGRAPH_URL } from 'src/utils/chains';
+import { DEFAULT_PROVIDER, GRANT_ROUND_MANAGER_ADDRESS, START_BLOCK, SUBGRAPH_URL } from 'src/utils/chains';
 // --- Data ---
 import useWalletStore from 'src/store/wallet';
 import { batchFilterCall, recursiveGraphFetch } from '../utils';
@@ -17,7 +17,7 @@ import { Ref } from 'vue';
 import { getGrantRoundGrantData } from './grantRounds';
 
 // --- pull in the registry contract
-const { default_provider, grantRoundManager } = useWalletStore();
+const { grantRoundManager } = useWalletStore();
 
 /**
  * @notice Get/Refresh all contributions
@@ -270,7 +270,7 @@ export function grantDonationListener(
     event: Event
   ) => {
     // console.log(name, grantId, tokenIn, donationAmount, rounds);
-    const blockNumber = await default_provider.value.getBlockNumber();
+    const blockNumber = await DEFAULT_PROVIDER.getBlockNumber();
     // get tx details to pull contributor details from
     const tx = await event.getTransaction();
     // log the new contribution

--- a/app/src/utils/data/contributions.ts
+++ b/app/src/utils/data/contributions.ts
@@ -17,7 +17,7 @@ import { Ref } from 'vue';
 import { getGrantRoundGrantData } from './grantRounds';
 
 // --- pull in the registry contract
-const { provider, grantRoundManager } = useWalletStore();
+const { default_provider, grantRoundManager } = useWalletStore();
 
 /**
  * @notice Get/Refresh all contributions
@@ -270,7 +270,7 @@ export function grantDonationListener(
     event: Event
   ) => {
     // console.log(name, grantId, tokenIn, donationAmount, rounds);
-    const blockNumber = await provider.value.getBlockNumber();
+    const blockNumber = await default_provider.value.getBlockNumber();
     // get tx details to pull contributor details from
     const tx = await event.getTransaction();
     // log the new contribution

--- a/app/src/utils/data/grantRounds.ts
+++ b/app/src/utils/data/grantRounds.ts
@@ -20,7 +20,13 @@ import { CLR, linear, InitArgs } from '@dgrants/dcurve';
 import { filterContributionsByGrantId, filterContributionsByGrantRound } from './contributions';
 import { getMetadata } from './ipfs';
 // --- Constants ---
-import { START_BLOCK, SUPPORTED_TOKENS_MAPPING, GRANT_REGISTRY_ADDRESS, SUBGRAPH_URL } from 'src/utils/chains';
+import {
+  START_BLOCK,
+  SUPPORTED_TOKENS_MAPPING,
+  GRANT_REGISTRY_ADDRESS,
+  SUBGRAPH_URL,
+  DEFAULT_PROVIDER,
+} from 'src/utils/chains';
 import {
   GRANT_ROUND_ABI,
   ERC20_ABI,
@@ -30,7 +36,7 @@ import {
 } from 'src/utils/constants';
 import { Ref } from 'vue';
 
-const { grantRoundManager, default_provider, provider } = useWalletStore();
+const { grantRoundManager, provider } = useWalletStore();
 
 /**
  * @notice Get/Refresh all GrantRound addresses
@@ -38,7 +44,7 @@ const { grantRoundManager, default_provider, provider } = useWalletStore();
  * @param {boolean} forceRefresh Force the cache to refresh
  */
 export async function getAllGrantRounds(forceRefresh = false) {
-  const latestBlockNumber = BigNumber.from(await default_provider.value.getBlockNumber()).toNumber();
+  const latestBlockNumber = BigNumber.from(await DEFAULT_PROVIDER.getBlockNumber()).toNumber();
 
   return await syncStorage(
     allGrantRoundsKey,
@@ -146,7 +152,7 @@ export async function getGrantRound(blockNumber: number, grantRoundAddress: stri
         donationTokenAddress,
       } = LocalForageData?.data?.grantRound || {};
       // no contract deployed here...
-      if ((await default_provider.value.getCode(grantRoundAddress)) === '0x') {
+      if ((await DEFAULT_PROVIDER.getCode(grantRoundAddress)) === '0x') {
         // return empty state
         return (
           LocalForageData || {
@@ -155,11 +161,11 @@ export async function getGrantRound(blockNumber: number, grantRoundAddress: stri
         );
       } else {
         // open the rounds contract
-        const roundContract = new Contract(grantRoundAddress, GRANT_ROUND_ABI, default_provider.value);
+        const roundContract = new Contract(grantRoundAddress, GRANT_ROUND_ABI, DEFAULT_PROVIDER);
         // collect the donationToken & matchingToken before promise.all'ing everything
         const matchingTokenAddress = matchingToken?.address || (await roundContract.matchingToken());
         // use matchingTokenContract to get balance
-        const matchingTokenContract = new Contract(matchingTokenAddress, ERC20_ABI, default_provider.value);
+        const matchingTokenContract = new Contract(matchingTokenAddress, ERC20_ABI, DEFAULT_PROVIDER);
         // full update of stored data
         if (forceRefresh || !LocalForageData) {
           // Define calls to be read using multicall

--- a/app/src/utils/data/grantRounds.ts
+++ b/app/src/utils/data/grantRounds.ts
@@ -36,7 +36,7 @@ import {
 } from 'src/utils/constants';
 import { Ref } from 'vue';
 
-const { grantRoundManager, provider } = useWalletStore();
+const { grantRoundManager } = useWalletStore();
 
 /**
  * @notice Get/Refresh all GrantRound addresses
@@ -459,7 +459,7 @@ async function updateGrantRound(
   refs: Record<string, Ref>
 ) {
   // blockNumber from the provider
-  const blockNumber = await provider.value.getBlockNumber();
+  const blockNumber = await DEFAULT_PROVIDER.getBlockNumber();
   // update _lsRoundAddresses
   void (await syncStorage(
     allGrantRoundsKey,
@@ -529,9 +529,9 @@ export function grantRoundCreatedListener(
   const listener = async (grantRoundAddress: string) => {
     console.log('New GrantRound created: ', grantRoundAddress);
     // open the rounds contract
-    const roundContract = new Contract(grantRoundAddress, GRANT_ROUND_ABI, provider.value);
+    const roundContract = new Contract(grantRoundAddress, GRANT_ROUND_ABI, DEFAULT_PROVIDER);
     // open the rounds contract
-    const matchingTokenContract = new Contract(await roundContract.matchingToken(), ERC20_ABI, provider.value);
+    const matchingTokenContract = new Contract(await roundContract.matchingToken(), ERC20_ABI, DEFAULT_PROVIDER);
     // update the grants round
     void updateGrantRound(grantRoundAddress, args, refs);
     // init and record the new listeners

--- a/app/src/utils/data/grantRounds.ts
+++ b/app/src/utils/data/grantRounds.ts
@@ -30,7 +30,7 @@ import {
 } from 'src/utils/constants';
 import { Ref } from 'vue';
 
-const { grantRoundManager, provider } = useWalletStore();
+const { grantRoundManager, default_provider, provider } = useWalletStore();
 
 /**
  * @notice Get/Refresh all GrantRound addresses
@@ -38,7 +38,7 @@ const { grantRoundManager, provider } = useWalletStore();
  * @param {boolean} forceRefresh Force the cache to refresh
  */
 export async function getAllGrantRounds(forceRefresh = false) {
-  const latestBlockNumber = BigNumber.from(await provider.value.getBlockNumber()).toNumber();
+  const latestBlockNumber = BigNumber.from(await default_provider.value.getBlockNumber()).toNumber();
 
   return await syncStorage(
     allGrantRoundsKey,
@@ -146,7 +146,7 @@ export async function getGrantRound(blockNumber: number, grantRoundAddress: stri
         donationTokenAddress,
       } = LocalForageData?.data?.grantRound || {};
       // no contract deployed here...
-      if ((await provider.value.getCode(grantRoundAddress)) === '0x') {
+      if ((await default_provider.value.getCode(grantRoundAddress)) === '0x') {
         // return empty state
         return (
           LocalForageData || {
@@ -155,11 +155,11 @@ export async function getGrantRound(blockNumber: number, grantRoundAddress: stri
         );
       } else {
         // open the rounds contract
-        const roundContract = new Contract(grantRoundAddress, GRANT_ROUND_ABI, provider.value);
+        const roundContract = new Contract(grantRoundAddress, GRANT_ROUND_ABI, default_provider.value);
         // collect the donationToken & matchingToken before promise.all'ing everything
         const matchingTokenAddress = matchingToken?.address || (await roundContract.matchingToken());
         // use matchingTokenContract to get balance
-        const matchingTokenContract = new Contract(matchingTokenAddress, ERC20_ABI, provider.value);
+        const matchingTokenContract = new Contract(matchingTokenAddress, ERC20_ABI, default_provider.value);
         // full update of stored data
         if (forceRefresh || !LocalForageData) {
           // Define calls to be read using multicall

--- a/app/src/utils/data/grants.ts
+++ b/app/src/utils/data/grants.ts
@@ -6,7 +6,7 @@ import { syncStorage } from 'src/utils/data/utils';
 import { BigNumber, BigNumberish, Event } from 'ethers';
 // --- Constants ---
 import { allGrantsKey } from 'src/utils/constants';
-import { START_BLOCK, SUBGRAPH_URL } from 'src/utils/chains';
+import { DEFAULT_PROVIDER, START_BLOCK, SUBGRAPH_URL } from 'src/utils/chains';
 // --- Data ---
 import useWalletStore from 'src/store/wallet';
 import { batchFilterCall, recursiveGraphFetch } from '../utils';
@@ -15,7 +15,7 @@ import { getAddress } from '../ethers';
 import { getMetadata } from './ipfs';
 
 // --- pull in the registry contract
-const { grantRegistry, default_provider } = useWalletStore();
+const { grantRegistry } = useWalletStore();
 
 /**
  * @notice Get/Refresh all Grants
@@ -24,7 +24,7 @@ const { grantRegistry, default_provider } = useWalletStore();
  */
 
 export async function getAllGrants(forceRefresh = false) {
-  const latestBlockNumber = BigNumber.from(await default_provider.value.getBlockNumber()).toNumber();
+  const latestBlockNumber = BigNumber.from(await DEFAULT_PROVIDER.getBlockNumber()).toNumber();
 
   return await syncStorage(
     allGrantsKey,
@@ -142,7 +142,7 @@ export function grantListener(name: string, refs: Record<string, Ref>) {
     void (await syncStorage(
       allGrantsKey,
       {
-        blockNumber: await default_provider.value.getBlockNumber(),
+        blockNumber: await DEFAULT_PROVIDER.getBlockNumber(),
       },
       async (LocalForageData?: LocalForageData | undefined, save?: () => void) => {
         // pull the indexed grants data from localStorage

--- a/app/src/utils/data/grants.ts
+++ b/app/src/utils/data/grants.ts
@@ -15,7 +15,7 @@ import { getAddress } from '../ethers';
 import { getMetadata } from './ipfs';
 
 // --- pull in the registry contract
-const { grantRegistry, provider } = useWalletStore();
+const { grantRegistry, default_provider } = useWalletStore();
 
 /**
  * @notice Get/Refresh all Grants
@@ -24,7 +24,7 @@ const { grantRegistry, provider } = useWalletStore();
  */
 
 export async function getAllGrants(forceRefresh = false) {
-  const latestBlockNumber = BigNumber.from(await provider.value.getBlockNumber()).toNumber();
+  const latestBlockNumber = BigNumber.from(await default_provider.value.getBlockNumber()).toNumber();
 
   return await syncStorage(
     allGrantsKey,
@@ -142,7 +142,7 @@ export function grantListener(name: string, refs: Record<string, Ref>) {
     void (await syncStorage(
       allGrantsKey,
       {
-        blockNumber: await provider.value.getBlockNumber(),
+        blockNumber: await default_provider.value.getBlockNumber(),
       },
       async (LocalForageData?: LocalForageData | undefined, save?: () => void) => {
         // pull the indexed grants data from localStorage

--- a/app/src/views/GrantRegistryGrantDetail.vue
+++ b/app/src/views/GrantRegistryGrantDetail.vue
@@ -331,7 +331,7 @@ function useGrantDetail() {
     grantContributions: allContributions,
     grantRoundsDonationToken: donationToken,
   } = useDataStore();
-  const { signer, provider, userAddress, grantRegistry, isCorrectNetwork } = useWalletStore();
+  const { signer, default_provider, userAddress, grantRegistry, isCorrectNetwork } = useWalletStore();
   const route = useRoute();
 
   // --- expose grant data ---
@@ -352,12 +352,12 @@ function useGrantDetail() {
   const txHash = ref<string>();
 
   watch(
-    () => [grant.value, grantId.value, rounds.value, roundsCLRData.value, provider.value],
+    () => [grant.value, grantId.value, rounds.value, roundsCLRData.value, default_provider.value],
     () => {
       // enter loading state between loads
       loading.value = true;
       // ensure the computed props are ready before fetching data
-      if (donationToken.value && rounds.value && roundsCLRData.value && provider.value) {
+      if (donationToken.value && rounds.value && roundsCLRData.value && default_provider.value) {
         // get all contributions for this grant
         const contributions = filterContributionsByGrantId(grantId.value, allContributions?.value || []);
         // sum all contributions made against this grant

--- a/app/src/views/GrantRegistryGrantDetail.vue
+++ b/app/src/views/GrantRegistryGrantDetail.vue
@@ -283,7 +283,7 @@ import useWalletStore from 'src/store/wallet';
 // --- Methods and Data ---
 import { LOREM_IPSOM_TEXT } from 'src/utils/constants';
 import { ContractTransaction } from 'src/utils/ethers';
-import { DGRANTS_CHAIN_ID } from 'src/utils/chains';
+import { DEFAULT_PROVIDER, DGRANTS_CHAIN_ID } from 'src/utils/chains';
 import {
   cleanTwitterUrl,
   formatNumber,
@@ -331,7 +331,7 @@ function useGrantDetail() {
     grantContributions: allContributions,
     grantRoundsDonationToken: donationToken,
   } = useDataStore();
-  const { signer, default_provider, userAddress, grantRegistry, isCorrectNetwork } = useWalletStore();
+  const { signer, userAddress, grantRegistry, isCorrectNetwork } = useWalletStore();
   const route = useRoute();
 
   // --- expose grant data ---
@@ -352,12 +352,12 @@ function useGrantDetail() {
   const txHash = ref<string>();
 
   watch(
-    () => [grant.value, grantId.value, rounds.value, roundsCLRData.value, default_provider.value],
+    () => [grant.value, grantId.value, rounds.value, roundsCLRData.value, DEFAULT_PROVIDER],
     () => {
       // enter loading state between loads
       loading.value = true;
       // ensure the computed props are ready before fetching data
-      if (donationToken.value && rounds.value && roundsCLRData.value && default_provider.value) {
+      if (donationToken.value && rounds.value && roundsCLRData.value && DEFAULT_PROVIDER) {
         // get all contributions for this grant
         const contributions = filterContributionsByGrantId(grantId.value, allContributions?.value || []);
         // sum all contributions made against this grant

--- a/app/src/views/GrantRegistryGrantDetail.vue
+++ b/app/src/views/GrantRegistryGrantDetail.vue
@@ -283,7 +283,7 @@ import useWalletStore from 'src/store/wallet';
 // --- Methods and Data ---
 import { LOREM_IPSOM_TEXT } from 'src/utils/constants';
 import { ContractTransaction } from 'src/utils/ethers';
-import { DEFAULT_PROVIDER, DGRANTS_CHAIN_ID } from 'src/utils/chains';
+import { DGRANTS_CHAIN_ID } from 'src/utils/chains';
 import {
   cleanTwitterUrl,
   formatNumber,
@@ -352,12 +352,12 @@ function useGrantDetail() {
   const txHash = ref<string>();
 
   watch(
-    () => [grant.value, grantId.value, rounds.value, roundsCLRData.value, DEFAULT_PROVIDER],
+    () => [grant.value, grantId.value, rounds.value, roundsCLRData.value],
     () => {
       // enter loading state between loads
       loading.value = true;
       // ensure the computed props are ready before fetching data
-      if (donationToken.value && rounds.value && roundsCLRData.value && DEFAULT_PROVIDER) {
+      if (donationToken.value && rounds.value && roundsCLRData.value) {
         // get all contributions for this grant
         const contributions = filterContributionsByGrantId(grantId.value, allContributions?.value || []);
         // sum all contributions made against this grant


### PR DESCRIPTION
#### Description

`DEFAULT_PROVIDER` from chains.ts  is now used for fetch operations instead of relying on the provider configured in the user's wallet.
Any contract interaction would continue use the rpc url configured in the wallet.


Refs: https://github.com/dcgtc/dgrants/issues/509
