### PR TITLE
Fixing whitelist

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/app",
-  "version": "0.2.13-567dfb5.0",
+  "version": "0.2.14-15c7cd6.0",
   "private": true,
   "scripts": {
     "clean": "rimraf dist",
@@ -14,9 +14,9 @@
     "prettier": "prettier --write ."
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.2.10-17e4017.0",
-    "@dgrants/dcurve": "^0.2.10-17e4017.0",
-    "@dgrants/types": "^0.2.10-17e4017.0",
+    "@dgrants/contracts": "^0.2.11-15c7cd6.0",
+    "@dgrants/dcurve": "^0.2.11-15c7cd6.0",
+    "@dgrants/types": "^0.2.11-15c7cd6.0",
     "@fusion-icons/vue": "^0.0.0",
     "@headlessui/vue": "^1.2.0",
     "@tailwindcss/aspect-ratio": "^0.2.1",

--- a/app/src/store/data.ts
+++ b/app/src/store/data.ts
@@ -305,9 +305,13 @@ export default function useDataStore() {
     const whitelistUrl = import.meta.env.VITE_GRANT_WHITELIST_URI;
     if (whitelistUrl) {
       const url = whitelistUrl + uniqueStr;
-      const json = await fetch(url).then((res) => res.json());
-      if (!json) return grants;
-      grants = grants.filter((grant) => json[DGRANTS_CHAIN_ID].includes(grant.id));
+      try {
+        const json = await fetch(url).then((res) => res.json());
+        if (!json) return grants;
+        grants = grants.filter((grant) => json[DGRANTS_CHAIN_ID].includes(grant.id));
+      } catch (err) {
+        return grants;
+      }
     }
 
     return {

--- a/app/src/store/data.ts
+++ b/app/src/store/data.ts
@@ -306,7 +306,7 @@ export default function useDataStore() {
     if (whitelistUrl) {
       const url = whitelistUrl + uniqueStr;
       const json = await fetch(url).then((res) => res.json());
-      approvedGrantsPk = json[DGRANTS_CHAIN_ID];
+      if (!json) return grants;
       grants = grants.filter((grant) => json[DGRANTS_CHAIN_ID].includes(grant.id));
     }
 

--- a/app/src/store/data.ts
+++ b/app/src/store/data.ts
@@ -293,12 +293,6 @@ export default function useDataStore() {
   }
 
   /**
-   * @notice helper function to filter approved grants
-   *
-   * @param grants Grant[] list of all grants
-   */
-
-  /**
    * @notice Call this method to poll now, then poll on each new block
    */
   async function startPolling() {

--- a/app/src/utils/utils.ts
+++ b/app/src/utils/utils.ts
@@ -65,7 +65,7 @@ export function daysAgo(val = 0) {
 // Convert unix ts to DD-MM-YYYY
 export function formatDate(dateStr: BigNumber): string {
   const date = new Date(BigNumber.from(dateStr).toNumber() * 1000);
-  return `${date.getDate()}-${date.getMonth()+1}-${date.getFullYear()}`;
+  return `${date.getDate()}-${date.getMonth() + 1}-${date.getFullYear()}`;
 }
 
 // Convert a unix ts to a toLocaleString

--- a/app/src/views/Home.vue
+++ b/app/src/views/Home.vue
@@ -213,7 +213,7 @@ export default defineComponent({
         if (_grants.value) {
           const grantsProxyArray = Object.assign({}, _grants.value);
           const grantsArray = Object.values(grantsProxyArray).map((item) => Object.assign({}, item));
-          const approvedCount = (await getApprovedGrants(grantsArray)).length;
+          const approvedCount = (await getApprovedGrants(grantsArray)).grants.length;
           validGrantsCount.value = approvedCount;
         } else {
           validGrantsCount.value = 0;

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@dgrants/contracts",
-  "version": "0.2.10-17e4017.0",
+  "version": "0.2.11-15c7cd6.0",
   "devDependencies": {
-    "@dgrants/types": "^0.2.10-17e4017.0",
+    "@dgrants/types": "^0.2.11-15c7cd6.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "3.4.1-solc-0.7-2",

--- a/dcurve/package.json
+++ b/dcurve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/dcurve",
-  "version": "0.2.10-17e4017.0",
+  "version": "0.2.11-15c7cd6.0",
   "private": true,
   "description": "distribution generator for GrantCLR in dgrants",
   "keywords": [
@@ -29,8 +29,8 @@
     "extends": "../package.json"
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.2.10-17e4017.0",
-    "@dgrants/utils": "^0.2.8-ad0866d.0",
+    "@dgrants/contracts": "^0.2.11-15c7cd6.0",
+    "@dgrants/utils": "^0.2.9-15c7cd6.0",
     "buffer": "^6.0.3",
     "ethers": "^5.4.6"
   },

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/types",
-  "version": "0.2.10-17e4017.0",
+  "version": "0.2.11-15c7cd6.0",
   "types": "src/index.d.ts",
   "scripts": {
     "build": "tsc -b .",

--- a/types/src/app.d.ts
+++ b/types/src/app.d.ts
@@ -39,4 +39,4 @@ export type FilterNavButton = {
 };
 
 // For the whitelist object we're getting
-export type Whitelist = Record<number, number[]>
+export type Whitelist = Record<number, number[]>;

--- a/types/src/app.d.ts
+++ b/types/src/app.d.ts
@@ -37,3 +37,6 @@ export type FilterNavButton = {
   label: string; // label to display in the button
   action?: (payload: MouseEvent) => void; // action to take when we click the button
 };
+
+// For the whitelist object we're getting
+export type Whitelist = Record<number, number[]>

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/utils",
-  "version": "0.2.8-ad0866d.0",
+  "version": "0.2.9-15c7cd6.0",
   "description": "common methods shared",
   "keywords": [
     "dgrants",


### PR DESCRIPTION
Whenever we fetch the whitelist I will cache it and in case of not being able to fetch the whitelist, I will use the cached one.

- [x] Check for a local cache of the whitelist and use that if it exists
- [x] If no local copy of the whitelist exists, display an error

Also, put the fallback strategy into a new function so adding "Additionally we should add a fallback URL for the whitelist which could be a different IPFS gateway or HTTP server" must be pretty straightforward whenever the fallback URL is ready.

**Suggestion: Using the cache for whitelisting while trying to fetch whitelist, will give slightly better UX with faster load time**

fixed #459 