### PR TITLE
error handling: decode metadataId

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/app",
-  "version": "0.2.9-9061a2e.0",
+  "version": "0.2.10-e65fa59.0",
   "private": true,
   "scripts": {
     "clean": "rimraf dist",

--- a/app/src/utils/data/ipfs.ts
+++ b/app/src/utils/data/ipfs.ts
@@ -10,6 +10,9 @@ const retrievalEndpoint = 'https://scopelift.b-cdn.net/ipfs';
 
 function assertIPFSPointer(logoPtr: MetaPtr | undefined) {
   if (!logoPtr) throw new Error('assertIPFSPointer: logoPtr is undefined');
+  if (typeof logoPtr == 'string') {
+    logoPtr = decodeMetadataId(logoPtr);
+  }
   const protocol = BigNumber.from(logoPtr.protocol).toString();
   if (protocol !== '1') throw new Error(`assertIPFSPointer: Expected protocol ID of 1, found ${protocol}`);
 }

--- a/app/src/utils/utils.ts
+++ b/app/src/utils/utils.ts
@@ -80,6 +80,10 @@ export function cleanTwitterUrl(url: string | undefined) {
 
 // Given a metadata pointer object, return a stringified version that can be used as an object key
 export function metadataId(metaPtr: MetaPtr): string {
+  if (typeof metaPtr == 'string') {
+    metaPtr = decodeMetadataId(metaPtr);
+  }
+
   return `${BigNumber.from(metaPtr.protocol).toString()}-${metaPtr.pointer}`;
 }
 


### PR DESCRIPTION
#### 

Grants don't load due to face that metaPtr is not stored as MetaPtr but instead as a string on the metadata
This is causing the functions to error out.

The right way to do this would be to 
- fix create grant flow
- update grants metadata

The quick fix to unblock the team would be to get this PR in which does an error handling


Bug: 


<img width="729" alt="Screenshot 2021-11-22 at 11 17 22 PM" src="https://user-images.githubusercontent.com/5358146/142911881-5e0b395e-18b3-43fe-af25-2c7871f80b7d.png">
