### PR TITLE
feat: records timestamps on grants and contributions

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/app",
-  "version": "0.2.10-e65fa59.0",
+  "version": "0.2.11-ca731a6.0",
   "private": true,
   "scripts": {
     "clean": "rimraf dist",
@@ -14,9 +14,9 @@
     "prettier": "prettier --write ."
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.2.8-ad0866d.0",
-    "@dgrants/dcurve": "^0.2.8-ad0866d.0",
-    "@dgrants/types": "^0.2.8-ad0866d.0",
+    "@dgrants/contracts": "^0.2.9-ca731a6.0",
+    "@dgrants/dcurve": "^0.2.9-ca731a6.0",
+    "@dgrants/types": "^0.2.9-ca731a6.0",
     "@fusion-icons/vue": "^0.0.0",
     "@headlessui/vue": "^1.2.0",
     "@tailwindcss/aspect-ratio": "^0.2.1",

--- a/app/src/utils/data/contributions.ts
+++ b/app/src/utils/data/contributions.ts
@@ -65,6 +65,7 @@ export async function getContributions(
                     from
                     hash
                     rounds
+                    createdAtTimestamp
                     lastUpdatedBlockNumber
                   }
                 }`,
@@ -82,6 +83,7 @@ export async function getContributions(
                   address: getAddress(contribution.from),
                   donationToken: donationToken,
                   txHash: contribution.hash,
+                  createdAt: contribution.createdAtTimestamp,
                   blockNumber: contribution.lastUpdatedBlockNumber,
                 };
               });
@@ -123,6 +125,7 @@ export async function getContributions(
                   tokenIn: getAddress(contribution?.args?.tokenIn),
                   donationToken: donationToken,
                   txHash: tx.hash,
+                  createdAt: contribution.args?.time,
                   blockNumber: tx.blockNumber,
                 };
               })
@@ -267,6 +270,7 @@ export function grantDonationListener(
     tokenIn: string,
     donationAmount: BigNumberish,
     grantRounds: string[],
+    time: BigNumber,
     event: Event
   ) => {
     // console.log(name, grantId, tokenIn, donationAmount, rounds);
@@ -301,6 +305,7 @@ export function grantDonationListener(
           tokenIn: tokenIn,
           txHash: tx.hash,
           blockNumber: tx.blockNumber,
+          createdAt: time,
         };
 
         if (save) {

--- a/app/src/utils/data/grants.ts
+++ b/app/src/utils/data/grants.ts
@@ -60,7 +60,6 @@ export async function getAllGrants(forceRefresh = false) {
               }`,
               fromBlock
             );
-            console.log(grants);
             // update each of the grants
             grants.forEach((grant: GrantSubgraph) => {
               const grantId = BigNumber.from(grant.id).toNumber();

--- a/app/src/utils/data/grants.ts
+++ b/app/src/utils/data/grants.ts
@@ -52,7 +52,10 @@ export async function getAllGrants(forceRefresh = false) {
                   id
                   owner
                   payee
-                  metaPtr
+                  metaPtr {
+                    protocol
+                    pointer
+                  }
                   createdAtTimestamp
                   lastUpdatedTimestamp
                   lastUpdatedBlockNumber

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@dgrants/contracts",
-  "version": "0.2.8-ad0866d.0",
+  "version": "0.2.9-ca731a6.0",
   "devDependencies": {
-    "@dgrants/types": "^0.2.8-ad0866d.0",
+    "@dgrants/types": "^0.2.9-ca731a6.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "3.4.1-solc-0.7-2",

--- a/dcurve/package.json
+++ b/dcurve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/dcurve",
-  "version": "0.2.8-ad0866d.0",
+  "version": "0.2.9-ca731a6.0",
   "private": true,
   "description": "distribution generator for GrantCLR in dgrants",
   "keywords": [
@@ -29,7 +29,7 @@
     "extends": "../package.json"
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.2.8-ad0866d.0",
+    "@dgrants/contracts": "^0.2.9-ca731a6.0",
     "@dgrants/utils": "^0.2.8-ad0866d.0",
     "buffer": "^6.0.3",
     "ethers": "^5.4.6"

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/types",
-  "version": "0.2.8-ad0866d.0",
+  "version": "0.2.9-ca731a6.0",
   "types": "src/index.d.ts",
   "scripts": {
     "build": "tsc -b .",

--- a/types/src/grants.d.ts
+++ b/types/src/grants.d.ts
@@ -26,8 +26,8 @@ export type GrantSubgraph = {
   payee: string;
   metaPtr: MetaPtr;
   lastUpdatedBlockNumber: number;
-  createdAt: BigNumber;
-  lastUpdated: BigNumber;
+  createdAtTimestamp: BigNumber;
+  lastUpdatedTimestamp: BigNumber;
 };
 // internally we cast id:BigNumber from GrantEthers to a number for Grant
 export type Grant = {
@@ -81,6 +81,7 @@ export type Contribution = {
   inRounds?: string[];
   donationToken?: TokenInfo;
   txHash?: string;
+  createdAt?: BigNumber;
   blockNumber?: number;
 };
 
@@ -103,6 +104,7 @@ type ContributionSubgraph = {
   from: string;
   hash: string;
   rounds: string[];
+  createdAtTimestamp: BigNumber;
   lastUpdatedBlockNumber: number;
 };
 


### PR DESCRIPTION
This PR stores timestamps in to the models for `Grants` and `Contributions`

--

Tested locally