### PR TITLE
fix: Lazy-load grant & grantRound metadata

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/app",
-  "version": "0.2.16-3fd9c6e.0",
+  "version": "0.2.17-596fc7b.0",
   "private": true,
   "scripts": {
     "clean": "rimraf dist",
@@ -14,9 +14,9 @@
     "prettier": "prettier --write ."
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.2.13-3fd9c6e.0",
-    "@dgrants/dcurve": "^0.2.13-3fd9c6e.0",
-    "@dgrants/types": "^0.2.13-3fd9c6e.0",
+    "@dgrants/contracts": "^0.2.14-596fc7b.0",
+    "@dgrants/dcurve": "^0.2.14-596fc7b.0",
+    "@dgrants/types": "^0.2.14-596fc7b.0",
     "@fusion-icons/vue": "^0.0.0",
     "@headlessui/vue": "^1.2.0",
     "@tailwindcss/aspect-ratio": "^0.2.1",

--- a/app/src/components/GrantCard.vue
+++ b/app/src/components/GrantCard.vue
@@ -17,7 +17,7 @@
       <div class="aspect-w-16 aspect-h-9 shadow-light">
         <img
           class="w-full h-full object-center object-cover group-hover:opacity-90"
-          :src="ptrToURI(logoPtr) || '/placeholder_round.svg'"
+          :src="(logoPtr?.protocol !== 0 && ptrToURI(logoPtr)) || '/placeholder_grant.svg'"
         />
       </div>
 

--- a/app/src/components/GrantDetailsRow.vue
+++ b/app/src/components/GrantDetailsRow.vue
@@ -3,7 +3,10 @@
   <section class="border-b border-grey-100 grid grid-cols-1 md:grid-cols-2">
     <!--grid:left (img)-->
     <figure class="aspect-w-16 aspect-h-9 shadow-light">
-      <img class="w-full h-full object-center object-cover" :src="ptrToURI(logoPtr) || '/placeholder_grant.svg'" />
+      <img
+        class="w-full h-full object-center object-cover"
+        :src="(logoPtr?.protocol !== 0 && ptrToURI(logoPtr)) || '/placeholder_grant.svg'"
+      />
     </figure>
 
     <!--grid:right (txt)-->

--- a/app/src/components/GrantRoundCard.vue
+++ b/app/src/components/GrantRoundCard.vue
@@ -5,7 +5,7 @@
     <div class="aspect-w-16 aspect-h-9 shadow-light">
       <img
         class="w-full h-full object-center object-cover group-hover:opacity-90"
-        :src="ptrToURI(logoPtr) || '/placeholder_round.svg'"
+        :src="(logoPtr?.protocol !== 0 && ptrToURI(logoPtr)) || '/placeholder_round.svg'"
       />
     </div>
 

--- a/app/src/store/data.ts
+++ b/app/src/store/data.ts
@@ -83,14 +83,24 @@ export default function useDataStore() {
    * @notice Check if a given contract has been deployed on the default provider
    */
   async function checkIsDeployed(name: string, address: string) {
-    // get the current donationToken
-    let check = await getStorageKey(name);
-    // set if absent
-    if (!check) {
-      await setStorageKey(name, (check = { data: { isDeployed: (await DEFAULT_PROVIDER.getCode(address)) !== '0x' } }));
+    // we only need to make these checks on dev
+    if (process.env.NODE_ENV === 'development') {
+      // get the current donationToken
+      let check = await getStorageKey(name);
+      // set if absent
+      if (!check) {
+        await setStorageKey(
+          name,
+          (check = { data: { isDeployed: (await DEFAULT_PROVIDER.getCode(address)) !== '0x' } })
+        );
+      }
+
+      // is this contract deployed?
+      return check.data.isDeployed as boolean;
+    } else {
+      // always deployed in prod
+      return true;
     }
-    // resolve the token address
-    return check.data.isDeployed as boolean;
   }
 
   /**

--- a/app/src/store/data.ts
+++ b/app/src/store/data.ts
@@ -166,9 +166,6 @@ export default function useDataStore() {
     // Fetch Metadata
     const grantMetaPtrs = grantsList.map((grant: Grant) => grant.metaPtr);
     const grantRoundMetaPtrs = grantRoundsList.map((grantRound: GrantRound) => grantRound.metaPtr);
-    // Fetch asynchronously without awaiting the response
-    void fetchMetaPtrs(grantMetaPtrs, grantMetadata);
-    void fetchMetaPtrs(grantRoundMetaPtrs, grantRoundMetadata);
 
     // Get latest set of contributions
     const contributions =
@@ -312,6 +309,10 @@ export default function useDataStore() {
         )
       );
     });
+
+    // Fetch asynchronously without awaiting the response
+    void fetchMetaPtrs(grantMetaPtrs, grantMetadata);
+    void fetchMetaPtrs(grantRoundMetaPtrs, grantRoundMetadata);
 
     // init complete
     return true;

--- a/app/src/utils/data/contributions.ts
+++ b/app/src/utils/data/contributions.ts
@@ -325,9 +325,6 @@ export function grantDonationListener(
       }
     );
 
-    // trustBonus
-    await getTrustBonusScores(blockNumber, contributions);
-
     // getGrantRoundGrantData
     void (await Promise.all(
       grantRounds.map(async (grantRoundAddress: string) => {

--- a/app/src/utils/data/grantRounds.ts
+++ b/app/src/utils/data/grantRounds.ts
@@ -43,9 +43,7 @@ const { grantRoundManager } = useWalletStore();
  *
  * @param {boolean} forceRefresh Force the cache to refresh
  */
-export async function getAllGrantRounds(forceRefresh = false) {
-  const latestBlockNumber = BigNumber.from(await DEFAULT_PROVIDER.getBlockNumber()).toNumber();
-
+export async function getAllGrantRounds(forceRefresh = false, latestBlockNumber: number) {
   return await syncStorage(
     allGrantRoundsKey,
     {
@@ -151,115 +149,104 @@ export async function getGrantRound(blockNumber: number, grantRoundAddress: stri
         funds,
         donationTokenAddress,
       } = LocalForageData?.data?.grantRound || {};
-      // no contract deployed here...
-      if ((await DEFAULT_PROVIDER.getCode(grantRoundAddress)) === '0x') {
-        // return empty state
-        return (
-          LocalForageData || {
-            data: {},
-          }
-        );
-      } else {
-        // open the rounds contract
-        const roundContract = new Contract(grantRoundAddress, GRANT_ROUND_ABI, DEFAULT_PROVIDER);
-        // collect the donationToken & matchingToken before promise.all'ing everything
-        const matchingTokenAddress = matchingToken?.address || (await roundContract.matchingToken());
-        // use matchingTokenContract to get balance
-        const matchingTokenContract = new Contract(matchingTokenAddress, ERC20_ABI, DEFAULT_PROVIDER);
-        // full update of stored data
-        if (forceRefresh || !LocalForageData) {
-          // Define calls to be read using multicall
-          [
-            donationTokenAddress,
-            startTime,
-            endTime,
-            metadataAdmin,
-            payoutAdmin,
-            registryAddress,
-            metaPtr,
-            hasPaidOut,
-            funds,
-          ] = await callMulticallContract([
-            // pull the grantRound data from its contract
-            {
-              target: grantRoundAddress,
-              contract: roundContract,
-              fns: [
-                'donationToken',
-                'startTime',
-                'endTime',
-                'metadataAdmin',
-                'payoutAdmin',
-                'registry',
-                'metaPtr',
-                'hasPaidOut',
-              ],
-            },
-            // get the balance from the matchinTokenContract
-            {
-              target: matchingTokenAddress,
-              contract: matchingTokenContract,
-              fns: [
-                {
-                  fn: 'balanceOf',
-                  args: [grantRoundAddress],
-                },
-              ],
-            },
-          ]);
-          // get the donation/matching token
-          matchingToken = SUPPORTED_TOKENS_MAPPING[matchingTokenAddress];
-          donationToken = SUPPORTED_TOKENS_MAPPING[donationTokenAddress];
-          // record the funds as a human readable number
-          funds = parseFloat(
-            formatUnits(BigNumber.from(funds), SUPPORTED_TOKENS_MAPPING[matchingTokenAddress].decimals)
-          );
-        } else if (LocalForageData && _lsBlockNumber < blockNumber) {
-          // get updated metadata
-          const [newMetaPtr, balance] = await Promise.all([
-            roundContract.metaPtr(),
-            matchingTokenContract.balanceOf(grantRoundAddress),
-          ]);
-          // update to the new metaPtr
-          metaPtr = newMetaPtr;
-          // update to the new balance
-          funds = parseFloat(formatUnits(balance, SUPPORTED_TOKENS_MAPPING[matchingTokenAddress].decimals)).toString();
-        }
-        // build status against now (unix)
-        const now = Date.now() / 1000;
-        // place the GrantRound details into a GrantRound object
-        const grantRound = {
-          grantRound: {
-            startTime,
-            endTime,
-            metadataAdmin,
-            payoutAdmin,
-            registryAddress,
-            hasPaidOut,
-            donationToken: donationToken,
-            matchingToken: matchingToken,
-            address: grantRoundAddress,
-            funds: funds,
-            status:
-              now >= BigNumber.from(startTime).toNumber() && now < BigNumber.from(endTime).toNumber()
-                ? 'Active'
-                : now < BigNumber.from(startTime).toNumber()
-                ? 'Upcoming'
-                : 'Completed',
-            registry: GRANT_REGISTRY_ADDRESS,
-            error: undefined,
-            metaPtr,
-          } as GrantRound,
-        };
 
-        // mark this for renewal
-        if (grantRound.grantRound.startTime && save) {
-          save();
-        }
-
-        // return the GrantRound data
-        return grantRound;
+      // open the rounds contract
+      const roundContract = new Contract(grantRoundAddress, GRANT_ROUND_ABI, DEFAULT_PROVIDER);
+      // collect the donationToken & matchingToken before promise.all'ing everything
+      const matchingTokenAddress = matchingToken?.address || (await roundContract.matchingToken());
+      // use matchingTokenContract to get balance
+      const matchingTokenContract = new Contract(matchingTokenAddress, ERC20_ABI, DEFAULT_PROVIDER);
+      // full update of stored data
+      if (forceRefresh || !LocalForageData) {
+        // Define calls to be read using multicall
+        [
+          donationTokenAddress,
+          startTime,
+          endTime,
+          metadataAdmin,
+          payoutAdmin,
+          registryAddress,
+          metaPtr,
+          hasPaidOut,
+          funds,
+        ] = await callMulticallContract([
+          // pull the grantRound data from its contract
+          {
+            target: grantRoundAddress,
+            contract: roundContract,
+            fns: [
+              'donationToken',
+              'startTime',
+              'endTime',
+              'metadataAdmin',
+              'payoutAdmin',
+              'registry',
+              'metaPtr',
+              'hasPaidOut',
+            ],
+          },
+          // get the balance from the matchinTokenContract
+          {
+            target: matchingTokenAddress,
+            contract: matchingTokenContract,
+            fns: [
+              {
+                fn: 'balanceOf',
+                args: [grantRoundAddress],
+              },
+            ],
+          },
+        ]);
+        // get the donation/matching token
+        matchingToken = SUPPORTED_TOKENS_MAPPING[matchingTokenAddress];
+        donationToken = SUPPORTED_TOKENS_MAPPING[donationTokenAddress];
+        // record the funds as a human readable number
+        funds = parseFloat(formatUnits(BigNumber.from(funds), SUPPORTED_TOKENS_MAPPING[matchingTokenAddress].decimals));
+      } else if (LocalForageData && _lsBlockNumber < blockNumber) {
+        // get updated metadata
+        const [newMetaPtr, balance] = await Promise.all([
+          roundContract.metaPtr(),
+          matchingTokenContract.balanceOf(grantRoundAddress),
+        ]);
+        // update to the new metaPtr
+        metaPtr = newMetaPtr;
+        // update to the new balance
+        funds = parseFloat(formatUnits(balance, SUPPORTED_TOKENS_MAPPING[matchingTokenAddress].decimals)).toString();
       }
+      // build status against now (unix)
+      const now = Date.now() / 1000;
+      // place the GrantRound details into a GrantRound object
+      const grantRound = {
+        grantRound: {
+          startTime,
+          endTime,
+          metadataAdmin,
+          payoutAdmin,
+          registryAddress,
+          hasPaidOut,
+          donationToken: donationToken,
+          matchingToken: matchingToken,
+          address: grantRoundAddress,
+          funds: funds,
+          status:
+            now >= BigNumber.from(startTime).toNumber() && now < BigNumber.from(endTime).toNumber()
+              ? 'Active'
+              : now < BigNumber.from(startTime).toNumber()
+              ? 'Upcoming'
+              : 'Completed',
+          registry: GRANT_REGISTRY_ADDRESS,
+          error: undefined,
+          metaPtr,
+        } as GrantRound,
+      };
+
+      // mark this for renewal
+      if (grantRound.grantRound.startTime && save) {
+        save();
+      }
+
+      // return the GrantRound data
+      return grantRound;
     }
   );
 }

--- a/app/src/utils/data/grants.ts
+++ b/app/src/utils/data/grants.ts
@@ -24,9 +24,7 @@ const { grantRegistry } = useWalletStore();
  * @param {boolean} forceRefresh Force the cache to refresh
  */
 
-export async function getAllGrants(forceRefresh = false) {
-  const latestBlockNumber = BigNumber.from(await DEFAULT_PROVIDER.getBlockNumber()).toNumber();
-
+export async function getAllGrants(forceRefresh = false, latestBlockNumber: number) {
   return await syncStorage(
     allGrantsKey,
     {

--- a/app/src/utils/data/grants.ts
+++ b/app/src/utils/data/grants.ts
@@ -221,10 +221,10 @@ export async function getApprovedGrants(grants: Grant[]) {
       grants.filter((grant) => whiteList[DGRANTS_CHAIN_ID].includes(grant.id));
 
     const fallback = async () => {
-      const cachedWhiteList: any = await getStorageKey('whitelist');
+      const cachedWhiteList = await getStorageKey('whitelist');
       if (cachedWhiteList) {
-        approvedGrantsPk = cachedWhiteList[DGRANTS_CHAIN_ID];
-        grants = filterWhiteListed(cachedWhiteList);
+        approvedGrantsPk = cachedWhiteList.data[DGRANTS_CHAIN_ID];
+        grants = filterWhiteListed(cachedWhiteList.data);
       } else {
         throw new Error("Failed to load whitelist and couldn't find a cached");
       }
@@ -235,7 +235,7 @@ export async function getApprovedGrants(grants: Grant[]) {
       if (!json) {
         await fallback();
       } else {
-        await setStorageKey('whitelist', json);
+        await setStorageKey('whitelist', { data: json });
         approvedGrantsPk = json[DGRANTS_CHAIN_ID];
         grants = filterWhiteListed(json);
       }

--- a/app/src/utils/data/ipfs.ts
+++ b/app/src/utils/data/ipfs.ts
@@ -92,8 +92,8 @@ export const fetchMetaPtrs = async (metaPtrs: MetaPtr[], metadata: Ref) => {
   if (Object.keys(newMetadata).length) {
     // save these pending metadata objects to state
     metadata.value = { ...metadata.value, ...newMetadata };
-    // resolve metadata via metaPtr and update state
-    void (await Promise.all(Object.keys(newMetadata).map(async (id) => getMetadata(decodeMetadataId(id), metadata))));
+    // resolve metadata via metaPtr and update state (no need to wait for resolution)
+    Object.keys(newMetadata).forEach((id) => getMetadata(decodeMetadataId(id), metadata));
   }
 
   return metadata;

--- a/app/src/utils/utils.ts
+++ b/app/src/utils/utils.ts
@@ -85,7 +85,7 @@ export function cleanTwitterUrl(url: string | undefined) {
 }
 
 // Given a metadata pointer object, return a stringified version that can be used as an object key
-export function metadataId(metaPtr: MetaPtr): string {
+export function metadataId(metaPtr: MetaPtr = { protocol: 0, pointer: '' }): string {
   if (typeof metaPtr == 'string') {
     metaPtr = decodeMetadataId(metaPtr);
   }

--- a/app/src/views/Cart.vue
+++ b/app/src/views/Cart.vue
@@ -77,7 +77,7 @@
                   class="link"
                   @click="pushRoute({ name: 'dgrants-id', params: { id: BigNumber.from(item.grantId).toString() } })"
                 >
-                  {{ grantMetadata[metadataId(item.metaPtr)]?.name }}
+                  {{ grantMetadata[metadataId(item.metaPtr)]?.name || '...' }}
                 </span>
               </div>
 

--- a/app/src/views/GrantRoundsList.vue
+++ b/app/src/views/GrantRoundsList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="Object.keys(grantRoundMetadata).length">
+  <div v-if="grantRounds">
     <!-- Simple breadcrumb pointing back to the landing -->
     <BaseHeader :breadcrumbContent="breadcrumb" name="Matching Rounds" />
 
@@ -15,9 +15,9 @@
                 :id="index"
                 :ptr="grantRound.metaPtr"
                 :address="grantRound.address"
-                :name="grantRoundMetadata[metadataId(grantRound.metaPtr)].name ?? ''"
+                :name="grantRoundMetadata[metadataId(grantRound.metaPtr)]?.name || '...'"
                 :logoPtr="grantRoundMetadata[metadataId(grantRound.metaPtr)]?.logoPtr"
-                :grantsTotal="grantRoundMetadata[metadataId(grantRound.metaPtr)].grants?.length ?? 0"
+                :grantsTotal="grantRoundMetadata[metadataId(grantRound.metaPtr)]?.grants?.length || 0"
                 :funds="`${formatNumber(grantRound.funds, 2)} ${grantRound.matchingToken.symbol}`"
               />
             </li>
@@ -128,6 +128,7 @@ export default defineComponent({
       daysAgo,
       formatAddress,
       formatNumber,
+      grantRounds,
       grantRoundLists,
       grantRoundMetadata,
       grantRoundsNav,

--- a/app/src/views/Home.vue
+++ b/app/src/views/Home.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="grantRoundMetadata && grantRounds && Object.keys(grantRoundMetadata).length == grantRounds.length">
+  <div v-if="grantRounds">
     <!--------------- INTRO --------------->
     <section class="px-4 md:px-12 py-20 border-b border-grey-100 text-center">
       <h1>Decentralized Grants</h1>
@@ -81,9 +81,9 @@
                 :id="index"
                 :ptr="grantRound.metaPtr"
                 :address="grantRound.address"
-                :name="grantRoundMetadata[metadataId(grantRound.metaPtr)].name ?? ''"
-                :logoPtr="grantRoundMetadata[metadataId(grantRound.metaPtr)].logoPtr"
-                :grantsTotal="grantRoundMetadata[metadataId(grantRound.metaPtr)].grants?.length ?? 0"
+                :name="grantRoundMetadata[metadataId(grantRound.metaPtr)]?.name || '...'"
+                :logoPtr="grantRoundMetadata[metadataId(grantRound.metaPtr)]?.logoPtr"
+                :grantsTotal="grantRoundMetadata[metadataId(grantRound.metaPtr)]?.grants?.length || 0"
                 :funds="`${formatNumber(grantRound.funds, 2)} ${grantRound.matchingToken.symbol}`"
               />
             </li>

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@dgrants/contracts",
-  "version": "0.2.13-3fd9c6e.0",
+  "version": "0.2.14-596fc7b.0",
   "devDependencies": {
-    "@dgrants/types": "^0.2.13-3fd9c6e.0",
+    "@dgrants/types": "^0.2.14-596fc7b.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "3.4.1-solc-0.7-2",

--- a/dcurve/package.json
+++ b/dcurve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/dcurve",
-  "version": "0.2.13-3fd9c6e.0",
+  "version": "0.2.14-596fc7b.0",
   "private": true,
   "description": "distribution generator for GrantCLR in dgrants",
   "keywords": [
@@ -29,8 +29,8 @@
     "extends": "../package.json"
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.2.13-3fd9c6e.0",
-    "@dgrants/utils": "^0.2.11-3fd9c6e.0",
+    "@dgrants/contracts": "^0.2.14-596fc7b.0",
+    "@dgrants/utils": "^0.2.12-596fc7b.0",
     "buffer": "^6.0.3",
     "ethers": "^5.4.6"
   },

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/types",
-  "version": "0.2.13-3fd9c6e.0",
+  "version": "0.2.14-596fc7b.0",
   "types": "src/index.d.ts",
   "scripts": {
     "build": "tsc -b .",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/utils",
-  "version": "0.2.11-3fd9c6e.0",
+  "version": "0.2.12-596fc7b.0",
   "description": "common methods shared",
   "keywords": [
     "dgrants",


### PR DESCRIPTION
This PR:

- ensures that we are lazy-loading metadata and shows placeholder content while we're waiting for the metaPtr content to be fetched from ipfs (Closes: #510)
- reduces the number of RPC calls we make on init
- allows for `metaPtr.protocol === 0` to default to placeholder images (Fixes: #532 && Fixes: #537)
- fixes typings on `cachedWhiteList` (`any` -> `LocalForageData`)
- only `checkIsDeployed` if were on dev (Fixes: #536)

--


