### PR TITLE
Disconnect wallet

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/app",
-  "version": "0.2.25-e975958.0",
+  "version": "0.2.26-16695ff.0",
   "private": true,
   "scripts": {
     "clean": "rimraf dist",
@@ -14,9 +14,9 @@
     "prettier": "prettier --write ."
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.2.22-e975958.0",
-    "@dgrants/dcurve": "^0.2.22-e975958.0",
-    "@dgrants/types": "^0.2.22-e975958.0",
+    "@dgrants/contracts": "^0.2.23-16695ff.0",
+    "@dgrants/dcurve": "^0.2.23-16695ff.0",
+    "@dgrants/types": "^0.2.23-16695ff.0",
     "@fusion-icons/vue": "^0.0.0",
     "@headlessui/vue": "^1.2.0",
     "@tailwindcss/aspect-ratio": "^0.2.1",

--- a/app/src/store/settings.ts
+++ b/app/src/store/settings.ts
@@ -12,6 +12,7 @@ const settings = {
 // Helper methods to load save items from local storage
 const load = (key: string) => window.localStorage.getItem(key);
 const save = (key: string, value: any) => window.localStorage.setItem(key, value); // eslint-disable-line @typescript-eslint/no-explicit-any
+const clear = (key: string) => window.localStorage.removeItem(key);
 
 // Shared state
 const lastWallet = ref<string>(); // name of last wallet used
@@ -27,10 +28,15 @@ export default function useSettingsStore() {
     save(settings.lastWallet, walletName);
   }
 
+  function clearLastWallet() {
+    clear(settings.lastWallet);
+  }
+
   return {
     initializeSettings,
     // Wallet
     setLastWallet,
+    clearLastWallet,
     lastWallet: computed(() => lastWallet.value),
   };
 }

--- a/app/src/store/wallet.ts
+++ b/app/src/store/wallet.ts
@@ -33,7 +33,7 @@ import { GRANT_REGISTRY_ABI, MULTICALL_ABI } from 'src/utils/constants';
 import { GrantRegistry, GrantRoundManager } from '@dgrants/contracts';
 
 const { startPolling } = useDataStore();
-const { setLastWallet } = useSettingsStore();
+const { setLastWallet, clearLastWallet } = useSettingsStore();
 const defaultChainId = SupportedChainId.MAINNET;
 
 // State variables
@@ -118,6 +118,7 @@ export default function useWalletStore() {
 
     resetState();
     onboard.walletReset();
+    clearLastWallet();
   }
 
   /**

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@dgrants/contracts",
-  "version": "0.2.22-e975958.0",
+  "version": "0.2.23-16695ff.0",
   "devDependencies": {
-    "@dgrants/types": "^0.2.22-e975958.0",
+    "@dgrants/types": "^0.2.23-16695ff.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "3.4.1-solc-0.7-2",

--- a/dcurve/package.json
+++ b/dcurve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/dcurve",
-  "version": "0.2.22-e975958.0",
+  "version": "0.2.23-16695ff.0",
   "private": true,
   "description": "distribution generator for GrantCLR in dgrants",
   "keywords": [
@@ -29,7 +29,7 @@
     "extends": "../package.json"
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.2.22-e975958.0",
+    "@dgrants/contracts": "^0.2.23-16695ff.0",
     "@dgrants/utils": "^0.2.14-cc1120d.0",
     "buffer": "^6.0.3",
     "ethers": "^5.4.6"

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/types",
-  "version": "0.2.22-e975958.0",
+  "version": "0.2.23-16695ff.0",
   "types": "src/index.d.ts",
   "scripts": {
     "build": "tsc -b .",


### PR DESCRIPTION
Based on discussions here #299 it seems like the functionality we want is to keep the wallet disconnected when user clicks the disconnect wallet button, rather than auto reconnecting again on refresh. It will still auto reconnect on refresh when a user has their wallet connected.

closes #299 