### PR TITLE
fix: 'require  is not defined' on prod for walletconnect

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/app",
-  "version": "0.2.26-16695ff.0",
+  "version": "0.2.27-87d3139.0",
   "private": true,
   "scripts": {
     "clean": "rimraf dist",
@@ -14,9 +14,9 @@
     "prettier": "prettier --write ."
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.2.23-16695ff.0",
-    "@dgrants/dcurve": "^0.2.23-16695ff.0",
-    "@dgrants/types": "^0.2.23-16695ff.0",
+    "@dgrants/contracts": "^0.2.24-87d3139.0",
+    "@dgrants/dcurve": "^0.2.24-87d3139.0",
+    "@dgrants/types": "^0.2.24-87d3139.0",
     "@fusion-icons/vue": "^0.0.0",
     "@headlessui/vue": "^1.2.0",
     "@tailwindcss/aspect-ratio": "^0.2.1",

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -5,6 +5,11 @@ import path from 'path';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [vue()],
+  build: {
+    commonjsOptions: {
+      transformMixedEsModules: true, // https://github.com/vitejs/vite/issues/4593
+    },
+  },
   resolve: {
     alias: {
       src: path.resolve(__dirname, 'src'),

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@dgrants/contracts",
-  "version": "0.2.23-16695ff.0",
+  "version": "0.2.24-87d3139.0",
   "devDependencies": {
-    "@dgrants/types": "^0.2.23-16695ff.0",
+    "@dgrants/types": "^0.2.24-87d3139.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "3.4.1-solc-0.7-2",

--- a/dcurve/package.json
+++ b/dcurve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/dcurve",
-  "version": "0.2.23-16695ff.0",
+  "version": "0.2.24-87d3139.0",
   "private": true,
   "description": "distribution generator for GrantCLR in dgrants",
   "keywords": [
@@ -29,7 +29,7 @@
     "extends": "../package.json"
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.2.23-16695ff.0",
+    "@dgrants/contracts": "^0.2.24-87d3139.0",
     "@dgrants/utils": "^0.2.14-cc1120d.0",
     "buffer": "^6.0.3",
     "ethers": "^5.4.6"

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/types",
-  "version": "0.2.23-16695ff.0",
+  "version": "0.2.24-87d3139.0",
   "types": "src/index.d.ts",
   "scripts": {
     "build": "tsc -b .",


### PR DESCRIPTION
Resolves #555, see that issue for details

This is not yet tested since this issue only happens in production build. @phutchins do branches deploy to a staging env we can test this on before merging?