### PR TITLE
fix: ensure matching is calculated once metadata loads

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/app",
-  "version": "0.2.27-87d3139.0",
+  "version": "0.2.28-f69d263.0",
   "private": true,
   "scripts": {
     "clean": "rimraf dist",


### PR DESCRIPTION
This PR ensures that the `watch` method in data is triggered when the `GrantRounds` metadata is resolved.

--

Tested locally on Rinkeby