### PR TITLE
fix: moves to a post request when calling the trust-bonus endpoint

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/app",
-  "version": "0.2.31-4add75c.0",
+  "version": "0.2.32-8a7e113.0",
   "private": true,
   "scripts": {
     "clean": "rimraf dist",
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@dgrants/contracts": "^0.2.24-87d3139.0",
-    "@dgrants/dcurve": "^0.2.24-87d3139.0",
+    "@dgrants/dcurve": "^0.2.25-8a7e113.0",
     "@dgrants/types": "^0.2.24-87d3139.0",
     "@fusion-icons/vue": "^0.0.0",
     "@headlessui/vue": "^1.2.0",

--- a/dcurve/package.json
+++ b/dcurve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/dcurve",
-  "version": "0.2.24-87d3139.0",
+  "version": "0.2.25-8a7e113.0",
   "private": true,
   "description": "distribution generator for GrantCLR in dgrants",
   "keywords": [
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@dgrants/contracts": "^0.2.24-87d3139.0",
-    "@dgrants/utils": "^0.2.14-cc1120d.0",
+    "@dgrants/utils": "^0.2.15-8a7e113.0",
     "buffer": "^6.0.3",
     "ethers": "^5.4.6"
   },

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/utils",
-  "version": "0.2.14-cc1120d.0",
+  "version": "0.2.15-8a7e113.0",
   "description": "common methods shared",
   "keywords": [
     "dgrants",

--- a/utils/src/trustBonus.ts
+++ b/utils/src/trustBonus.ts
@@ -29,10 +29,13 @@ export const fetchTrustBonusScore = async (addresses: string[]): Promise<TrustBo
   // filter any falseys before making the fetch to prevent [undefined] returning a 400: Bad Request
   if (addresses.filter((v) => v).length == 0) return result;
 
-  const url = `https://gitcoin.co/grants/v1/api/trust-bonus?addresses=${addresses.join(',')}`;
-
   try {
-    const response = await fetch(url);
+    const response = await fetch('https://gitcoin.co/grants/v1/api/trust-bonus', {
+      method: 'POST',
+      body: JSON.stringify({
+        addresses: addresses,
+      }),
+    });
     const trustBonusScores = await response.json();
     result.data = trustBonusScores;
     return result;


### PR DESCRIPTION
This PR will fix the `414 Request-URI Too Large` error we are seeing in production

--

Tested the call locally