### PR TITLE
fix: ensures metadata is present before checking the content of the grants property

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/app",
-  "version": "0.2.32-8a7e113.0",
+  "version": "0.2.33-7a451e7.0",
   "private": true,
   "scripts": {
     "clean": "rimraf dist",

--- a/app/src/store/cart.ts
+++ b/app/src/store/cart.ts
@@ -393,7 +393,8 @@ export default function useCartStore() {
     return cart.value
       .map((item) =>
         (grantRounds.value || []).reduce((inRound: boolean, round) => {
-          return inRound || grantRoundMetadata.value[metadataId(round.metaPtr)].grants?.includes(item.grantId) || false;
+          const metadata = grantRoundMetadata.value[metadataId(round.metaPtr)];
+          return inRound || metadata?.grants?.includes(item.grantId) || false;
         }, false)
       )
       .reduce((inRound, isInRound) => inRound || isInRound, false);


### PR DESCRIPTION
This PR will fix an error on the cart where we were checking the contents of the metadata before it was available/resolved.

--

Fixes: #577