### PR TITLE
feat: adds `GrantRoundsDonations` to source all contributions by round

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/app",
-  "version": "0.2.39-21b64c0.0",
+  "version": "0.2.40-e0c1210.0",
   "private": true,
   "scripts": {
     "clean": "rimraf dist",
@@ -14,9 +14,9 @@
     "prettier": "prettier --write ."
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.2.27-3fff2ae.0",
-    "@dgrants/dcurve": "^0.2.29-21b64c0.0",
-    "@dgrants/types": "^0.2.27-3fff2ae.0",
+    "@dgrants/contracts": "^0.2.28-e0c1210.0",
+    "@dgrants/dcurve": "^0.2.30-e0c1210.0",
+    "@dgrants/types": "^0.2.28-e0c1210.0",
     "@fusion-icons/vue": "^0.0.0",
     "@headlessui/vue": "^1.2.0",
     "@tailwindcss/aspect-ratio": "^0.2.1",

--- a/app/src/utils/constants.ts
+++ b/app/src/utils/constants.ts
@@ -52,6 +52,7 @@ export const trustBonusKey = 'TrustBonus';
 
 // LocalForage key-prefixes (partial key, we store an object for each instance)
 export const grantRoundKeyPrefix = 'GrantRound-';
+export const grantRoundDonationsKeyPrefix = 'GrantRoundDonations-';
 export const grantRoundsCLRDataKeyPrefix = 'GrantRoundsGrantData-';
 
 export const NO_LOGO_OBJECT = { protocol: 0, pointer: '' };

--- a/app/src/utils/data/grantRounds.ts
+++ b/app/src/utils/data/grantRounds.ts
@@ -295,7 +295,7 @@ export async function getGrantRoundDonations(
                 }
               }`,
               fromBlock,
-              // limit the results to just donations to this grant
+              // limit the results to just donations sent to this grantRound
               `round: "${grantRoundAddress}"`
             );
             // update each of the grants

--- a/app/src/utils/data/grants.ts
+++ b/app/src/utils/data/grants.ts
@@ -24,7 +24,7 @@ const { grantRegistry } = useWalletStore();
  * @param {boolean} forceRefresh Force the cache to refresh
  */
 
-export async function getAllGrants(forceRefresh = false, latestBlockNumber: number) {
+export async function getAllGrants(latestBlockNumber: number, forceRefresh = false) {
   return await syncStorage(
     allGrantsKey,
     {

--- a/app/src/utils/utils.ts
+++ b/app/src/utils/utils.ts
@@ -445,6 +445,7 @@ export const recursiveGraphFetch = async (
   key: string,
   query: (filter: string) => string,
   fromBlock: number,
+  additionalFilter = '',
   before: any[] = [] // eslint-disable-line @typescript-eslint/no-explicit-any
 ): // eslint-disable-next-line @typescript-eslint/no-explicit-any
 Promise<any[]> => {
@@ -461,6 +462,7 @@ Promise<any[]> => {
         where: {
           ${fromId ? `id_gt: "${fromId}",` : ''}
           ${fromBlock ? `lastUpdatedBlockNumber_gte: "${fromBlock}",` : ''}
+          ${additionalFilter}
         }
       `),
     }),
@@ -475,6 +477,6 @@ Promise<any[]> => {
     return [...before];
   } else {
     // return the result combined with the next page
-    return await recursiveGraphFetch(url, key, query, fromBlock, [...before, ...json.data[key]]);
+    return await recursiveGraphFetch(url, key, query, fromBlock, additionalFilter, [...before, ...json.data[key]]);
   }
 };

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@dgrants/contracts",
-  "version": "0.2.27-3fff2ae.0",
+  "version": "0.2.28-e0c1210.0",
   "devDependencies": {
-    "@dgrants/types": "^0.2.27-3fff2ae.0",
+    "@dgrants/types": "^0.2.28-e0c1210.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "3.4.1-solc-0.7-2",

--- a/dcurve/package.json
+++ b/dcurve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/dcurve",
-  "version": "0.2.29-21b64c0.0",
+  "version": "0.2.30-e0c1210.0",
   "private": true,
   "description": "distribution generator for GrantCLR in dgrants",
   "keywords": [
@@ -29,7 +29,7 @@
     "extends": "../package.json"
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.2.27-3fff2ae.0",
+    "@dgrants/contracts": "^0.2.28-e0c1210.0",
     "@dgrants/utils": "^0.2.15-8a7e113.0",
     "buffer": "^6.0.3",
     "ethers": "^5.4.6"

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/types",
-  "version": "0.2.27-3fff2ae.0",
+  "version": "0.2.28-e0c1210.0",
   "types": "src/index.d.ts",
   "scripts": {
     "build": "tsc -b .",

--- a/types/src/grantRounds.d.ts
+++ b/types/src/grantRounds.d.ts
@@ -3,15 +3,53 @@ import { TokenInfo } from '@uniswap/token-lists';
 import { Contribution, GrantPrediction, MetaPtr } from './grants';
 
 /**
- * Data types for entity being pulled from the subgraph
+ * Data types for GrantRound entity being pulled from the subgraph
  *
  * @type GrantRoundSubgraph
  * @field {address} grant round address
  * @field {lastUpdatedBlockNumber} the blockNumber on which this entity was lastUpdated
  */
 export type GrantRoundSubgraph = {
+  id: string;
   address: string;
   lastUpdatedBlockNumber: number;
+};
+
+/**
+ * Data types for GrantRoundDonations entity being pulled from the subgraph
+ *
+ * @type GrantRoundDonationSubgraph
+ * @field {contributor} the contributors address
+ * @field {amount} the amount being contributed
+ * @field {hash} the txHash associated with the transaction
+ * @field {createdAtTimestamp} the ts related to this contribution
+ * @field {lastUpdatedBlockNumber} the blockNumber on which this entity was created
+ */
+export type GrantRoundDonationSubgraph = {
+  id: string;
+  contributor: string;
+  amount: BigNumberish;
+  hash: string;
+  createdAtTimestamp: BigNumberish;
+  lastUpdatedBlockNumber: number;
+};
+
+/**
+ * Data types for GrantRoundDonations entity being pulled from storage
+ *
+ * @type GrantRoundDonations
+ * @field {contributor} the contributors address
+ * @field {amount} the amount being contributed
+ * @field {txHash} the txHash associated with the transaction
+ * @field {createdAt} the ts related to this contribution
+ * @field {blockNumber} the blockNumber on which this entity was created
+ */
+export type GrantRoundDonation = {
+  contributor: string;
+  amount: BigNumberish;
+  txHash: string;
+  createdAt: BigNumberish;
+  blockNumber: number;
 };
 
 /**


### PR DESCRIPTION
This PR adds a data utility to fetch `GrantRoundDonations` and exports `GrantRoundsDonations` from the data store.

--

Relates to: https://github.com/dcgtc/dgrants/issues/322#issuecomment-988965316

--

Depends on: https://github.com/dcgtc/dgrants-subgraph/pull/12

--

This can be tested on `Rinkeby` by updating the `subgraphUrl` to `https://api.thegraph.com/subgraphs/name/gdixon/dgrants-graph-rinkeby`