### PR TITLE
feat: allows for donate to dgrants btn to be disabled/configured

### DIFF
--- a/app/.env.template
+++ b/app/.env.template
@@ -12,6 +12,7 @@ VITE_GRANT_WHITELIST_URI=https://storageapi.fleek.co/phutchins-team-bucket/dgran
 # Production overrides
 # ----------------------------------
 # VITE_MAINTENANCE_MODE=0
+# VITE_DGRANTS_GRANT_ID=false
 # VITE_GRANT_ROUND_MANAGER=
 # VITE_GRANT_REGISTRY=
 # VITE_DEFAULT_RPC_URL=

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/app",
-  "version": "0.2.35-d93ee25.0",
+  "version": "0.2.36-3fff2ae.0",
   "private": true,
   "scripts": {
     "clean": "rimraf dist",
@@ -14,9 +14,9 @@
     "prettier": "prettier --write ."
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.2.26-d93ee25.0",
-    "@dgrants/dcurve": "^0.2.27-d93ee25.0",
-    "@dgrants/types": "^0.2.26-d93ee25.0",
+    "@dgrants/contracts": "^0.2.27-3fff2ae.0",
+    "@dgrants/dcurve": "^0.2.28-3fff2ae.0",
+    "@dgrants/types": "^0.2.27-3fff2ae.0",
     "@fusion-icons/vue": "^0.0.0",
     "@headlessui/vue": "^1.2.0",
     "@tailwindcss/aspect-ratio": "^0.2.1",

--- a/app/src/components/About.vue
+++ b/app/src/components/About.vue
@@ -34,7 +34,11 @@
 
         <!-- ToDo. Link to the real dGrant grant -->
         <div class="mt-16 flex flex-wrap gap-4">
-          <router-link to="/dgrants/0" @click="emitEvent('toggleAbout')">
+          <router-link
+            v-if="dgrantsGrantID && dgrantsGrantID !== 'false'"
+            :to="`/dgrants/${dgrantsGrantID}`"
+            @click="emitEvent('toggleAbout')"
+          >
             <button class="btn">
               <span>donate to <span class="text-teal">d</span>grants</span>
             </button>
@@ -79,11 +83,16 @@
 
 <script lang="ts">
 import { defineComponent, onMounted, ref } from 'vue';
+// --- Icons ---
 import { CloseIcon as XIcon } from '@fusion-icons/vue/interface';
 import { TwitterIcon as TwitterIcon } from '@fusion-icons/vue/interface';
 import { GithubIcon as GithubIcon } from '@fusion-icons/vue/interface';
 
+// package.json is used to inform the displayed version
 import packagejson from './../../package.json';
+
+// allow for the dgrants ID to be set in .env
+const dgrantsGrantID = import.meta.env.VITE_DGRANTS_GRANT_ID || false;
 
 function useContributors() {
   type Contributor = {
@@ -117,7 +126,7 @@ export default defineComponent({
   components: { XIcon, TwitterIcon, GithubIcon },
   setup(_props, context) {
     const emitEvent = (eventName: string) => context.emit(eventName);
-    return { emitEvent, packagejson, ...useContributors() };
+    return { dgrantsGrantID, emitEvent, packagejson, ...useContributors() };
   },
 });
 </script>

--- a/app/src/shims.d.ts
+++ b/app/src/shims.d.ts
@@ -8,11 +8,12 @@ declare module '*.vue' {
 // Shims for environment variables
 interface ImportMeta {
   env: {
-    VITE_BLOCKNATIVE_API_KEY: string;
     VITE_ALCHEMY_API_KEY: string;
+    VITE_BLOCKNATIVE_API_KEY: string;
     VITE_FLEEK_STORAGE_API_KEY: string;
-    VITE_DGRANTS_CHAIN_ID: string;
     VITE_GRANT_WHITELIST_URI: string;
+    VITE_DGRANTS_CHAIN_ID: string;
+    VITE_DGRANTS_GRANT_ID?: string;
     VITE_MAINTENANCE_MODE?: string;
     VITE_GRANT_REGISTRY?: string;
     VITE_GRANT_ROUND_MANAGER?: string;

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@dgrants/contracts",
-  "version": "0.2.26-d93ee25.0",
+  "version": "0.2.27-3fff2ae.0",
   "devDependencies": {
-    "@dgrants/types": "^0.2.26-d93ee25.0",
+    "@dgrants/types": "^0.2.27-3fff2ae.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "3.4.1-solc-0.7-2",

--- a/dcurve/package.json
+++ b/dcurve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/dcurve",
-  "version": "0.2.27-d93ee25.0",
+  "version": "0.2.28-3fff2ae.0",
   "private": true,
   "description": "distribution generator for GrantCLR in dgrants",
   "keywords": [
@@ -29,7 +29,7 @@
     "extends": "../package.json"
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.2.26-d93ee25.0",
+    "@dgrants/contracts": "^0.2.27-3fff2ae.0",
     "@dgrants/utils": "^0.2.15-8a7e113.0",
     "buffer": "^6.0.3",
     "ethers": "^5.4.6"

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/types",
-  "version": "0.2.26-d93ee25.0",
+  "version": "0.2.27-3fff2ae.0",
   "types": "src/index.d.ts",
   "scripts": {
     "build": "tsc -b .",


### PR DESCRIPTION
This PR adds the `VITE_DGRANTS_GRANT_ID` `.env` value to allow the `Donate to dGrants` button to be disabled/configured in the build.

--

Closes: #585 