### PR TITLE
fix: ensures cache persists a page reload

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/app",
-  "version": "0.2.40-e0c1210.0",
+  "version": "0.2.41-8dc1553.0",
   "private": true,
   "scripts": {
     "clean": "rimraf dist",
@@ -14,9 +14,9 @@
     "prettier": "prettier --write ."
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.2.28-e0c1210.0",
-    "@dgrants/dcurve": "^0.2.30-e0c1210.0",
-    "@dgrants/types": "^0.2.28-e0c1210.0",
+    "@dgrants/contracts": "^0.2.29-8dc1553.0",
+    "@dgrants/dcurve": "^0.2.31-8dc1553.0",
+    "@dgrants/types": "^0.2.29-8dc1553.0",
     "@fusion-icons/vue": "^0.0.0",
     "@headlessui/vue": "^1.2.0",
     "@tailwindcss/aspect-ratio": "^0.2.1",

--- a/app/src/store/data.ts
+++ b/app/src/store/data.ts
@@ -376,15 +376,17 @@ export default function useDataStore() {
 
     // record the network value to detect changes
     const networkValue = (await getStorageKey('network'))?.data || network.value;
+
     // watch the network
     watch(
       () => [network.value],
       async () => {
         // clear storage and poll again for all network changes after first load
-        if (networkValue && networkValue.chainId !== network.value?.chainId) {
+        if (networkValue && network.value && networkValue.chainId !== network.value?.chainId) {
           void (await DefaultStorage.clear());
-          void (await init());
         }
+        // init on network change
+        void (await init());
         // update for next time
         await setStorageKey('network', { data: { chainId: network.value?.chainId } });
       },
@@ -392,8 +394,6 @@ export default function useDataStore() {
         immediate: true,
       }
     );
-    // init the current state
-    void (await init());
   }
 
   return {

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@dgrants/contracts",
-  "version": "0.2.28-e0c1210.0",
+  "version": "0.2.29-8dc1553.0",
   "devDependencies": {
-    "@dgrants/types": "^0.2.28-e0c1210.0",
+    "@dgrants/types": "^0.2.29-8dc1553.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "3.4.1-solc-0.7-2",

--- a/dcurve/package.json
+++ b/dcurve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/dcurve",
-  "version": "0.2.30-e0c1210.0",
+  "version": "0.2.31-8dc1553.0",
   "private": true,
   "description": "distribution generator for GrantCLR in dgrants",
   "keywords": [
@@ -29,7 +29,7 @@
     "extends": "../package.json"
   },
   "dependencies": {
-    "@dgrants/contracts": "^0.2.28-e0c1210.0",
+    "@dgrants/contracts": "^0.2.29-8dc1553.0",
     "@dgrants/utils": "^0.2.15-8a7e113.0",
     "buffer": "^6.0.3",
     "ethers": "^5.4.6"

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dgrants/types",
-  "version": "0.2.28-e0c1210.0",
+  "version": "0.2.29-8dc1553.0",
   "types": "src/index.d.ts",
   "scripts": {
     "build": "tsc -b .",


### PR DESCRIPTION
On page-load the `network.value` was `undefined` which caused the `immediate` watcher to clear the storage. 

This PR corrects that behaviour and will ensure that the cache persists between page reloads. 

--

Fixes: #587 

-- 

Tested locally